### PR TITLE
core plugin for custom chat commands

### DIFF
--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -1,6 +1,7 @@
 import { GenlitePluginLoader } from "./genlite-plugin-loader.class";
 import { GenLiteNotificationPlugin } from "./plugins/genlite-notification.plugin";
 import { GenLiteSettingsPlugin } from "./plugins/genlite-settings.plugin";
+import { GenLiteCommandsPlugin } from "./plugins/genlite-commands.plugin";
 
 export class GenLite {
     static pluginName = 'GenLite';
@@ -11,6 +12,7 @@ export class GenLite {
 
     notifications: GenLiteNotificationPlugin;
     settings: GenLiteSettingsPlugin;
+	commands: GenLiteCommandsPlugin;
 
     /** We allow setting "any field, to anything" in order to load core features such as genlite.notifications */
     [key: string]: any;

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -12,7 +12,7 @@ export class GenLite {
 
     notifications: GenLiteNotificationPlugin;
     settings: GenLiteSettingsPlugin;
-	commands: GenLiteCommandsPlugin;
+    commands: GenLiteCommandsPlugin;
 
     /** We allow setting "any field, to anything" in order to load core features such as genlite.notifications */
     [key: string]: any;

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -85,5 +85,5 @@ declare const WorldItem: {
 };
 
 declare const Chat: {
-	[key: string]: any,
+    [key: string]: any,
 };

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -83,3 +83,7 @@ declare const NETWORK: {
 declare const WorldItem: {
     [key: string]: any,
 };
+
+declare const Chat: {
+	[key: string]: any,
+};

--- a/src/core/plugins/genlite-commands.plugin.ts
+++ b/src/core/plugins/genlite-commands.plugin.ts
@@ -1,0 +1,70 @@
+export class GenLiteCommandsPlugin {
+    public static pluginName = 'GenLiteCommandsPlugin';
+    public static customCommandPrefix = '//';
+
+    private commands: {[key: string]: (a: string) => void} = {};
+    private originalProcessInput: Function;
+
+    async init() {
+        window.genlite.registerModule(this);
+
+        this.originalProcessInput = Chat.prototype.processInput;
+        this.register("help", function (s) {
+            let helpStr = Object.keys(window.genlite.commands.commands).join(" ");
+            window.genlite.commands.print("GenLite Commands");
+            window.genlite.commands.print(helpStr);
+        });
+    }
+
+    processInput(plugin, originalFunction) {
+        const self = (this as any);
+
+        let text = self.DOM_input.value;
+        if (text.startsWith(GenLiteCommandsPlugin.customCommandPrefix)) {
+            self.DOM_input.value = '';
+            plugin.handleCommand(text);
+        } else {
+            originalFunction.bind(self)();
+        }
+    }
+
+    public loginOK() {
+        CHAT.processInput = this.processInput.bind(
+            CHAT,
+            this,
+            this.originalProcessInput,
+        );
+    }
+
+    public handleCommand(text: string) {
+        let end = text.indexOf(" ");
+        if (end == -1) {
+            // there is no space, use full string
+            end = text.length;
+        }
+        let command = text.slice(GenLiteCommandsPlugin.customCommandPrefix.length, end);
+        let args = text.slice(end + 1);
+        if (command in this.commands) {
+            CHAT.addGameMessage(text);
+            this.commands[command](args);
+        } else {
+            let helpStr = Object.keys(window.genlite.commands.commands).join(" ");
+            this.print("invalid command\"" + command + "\". Options: " + helpStr);
+        }
+    }
+
+    public register(command: string, handler: (a: string) => void): boolean {
+        if (command in this.commands || command.includes(" ")) {
+            // command is already registered
+            return false;
+        }
+
+        this.commands[command] = handler;
+        return true;
+    }
+
+    public print(text: string) {
+        CHAT.addGameMessage(text);
+    }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { GenLite } from "./core/genlite.class";
 import { GenLiteNotificationPlugin } from "./core/plugins/genlite-notification.plugin";
 import { GenLiteSettingsPlugin } from "./core/plugins/genlite-settings.plugin";
+import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
 
 /** Official Plugins */
 import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
@@ -26,6 +27,7 @@ import {GenLiteLocationsPlugin} from "./plugins/genlite-locations.plugin";
     /** Core Features */
     genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
     genlite.settings = await genlite.pluginLoader.addPlugin(GenLiteSettingsPlugin);
+	genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
 
     /** Official Plugins */
     await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {GenLiteLocationsPlugin} from "./plugins/genlite-locations.plugin";
     /** Core Features */
     genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
     genlite.settings = await genlite.pluginLoader.addPlugin(GenLiteSettingsPlugin);
-	genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
+    genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
 
     /** Official Plugins */
     await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);


### PR DESCRIPTION
Allows plugins to register chat command handlers using `window.genlite.commands.register(name, fn)`.

Because there is no defined list of Genfanad commands (they are hardcoded if statements), we can't use the single slash prefix without possible conflict with current or future commands. Instead, this consumes all chat messages that begin with double slash "//" and interprets them as a GenLite command. All other messages will be forwarded to the usual Genfanad chat processing function.

This should not interfere with usual chat, except that users will no longer be able to send a chat message beginning with two slashes.

