### PR TITLE
update command plugin, help text, remove commands, disable echo

### DIFF
--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -3,6 +3,14 @@ declare interface Window {
     [key: string]: any,
 };
 
+declare interface CommandSpec {
+    command: string,
+    handler: (a: string) => void,
+    helpFunction: (a: string) => string,
+    helpText: string,
+    echo: boolean,
+};
+
 /** Library globals */
 declare const THREE: {
     items: any,

--- a/src/core/plugins/genlite-commands.plugin.ts
+++ b/src/core/plugins/genlite-commands.plugin.ts
@@ -2,7 +2,7 @@ export class GenLiteCommandsPlugin {
     public static pluginName = 'GenLiteCommandsPlugin';
     public static customCommandPrefix = '//';
 
-    private commands: {[key: string]: (a: string) => void} = {};
+    private commands: {[key: string]: CommandSpec} = {};
     private originalProcessInput: Function;
 
     async init() {
@@ -10,10 +10,37 @@ export class GenLiteCommandsPlugin {
 
         this.originalProcessInput = Chat.prototype.processInput;
         this.register("help", function (s) {
-            let helpStr = Object.keys(window.genlite.commands.commands).join(" ");
-            window.genlite.commands.print("GenLite Commands");
-            window.genlite.commands.print(helpStr);
-        });
+            if (!s) {
+                let helpStr = Object.keys(window.genlite.commands.commands).join(", ");
+                window.genlite.commands.print("GenLite Commands");
+                window.genlite.commands.print(helpStr);
+                return;
+            }
+
+            let end = s.indexOf(" ");
+            if (end == -1) {
+                // there is no space, use full string
+                end = s.length;
+            }
+            let command = s.slice(0, end);
+            let args = s.slice(end + 1);
+
+            if (command in window.genlite.commands.commands) {
+                let spec = window.genlite.commands.commands[command];
+                if (spec.helpFunction) {
+                    var text = spec.helpFunction(args);
+                    if (text != null && text != "") {
+                        window.genlite.commands.print(text);
+                    }
+                } else if (spec.helpText) {
+                    window.genlite.commands.print(spec.helpText);
+                } else {
+                    window.genlite.commands.print("no help defined for this command");
+                }
+            } else {
+                window.genlite.commands.print("no such command");
+            }
+        }, "display help text for a command: '//help <command>'");
     }
 
     processInput(plugin, originalFunction) {
@@ -45,26 +72,73 @@ export class GenLiteCommandsPlugin {
         let command = text.slice(GenLiteCommandsPlugin.customCommandPrefix.length, end);
         let args = text.slice(end + 1);
         if (command in this.commands) {
-            CHAT.addGameMessage(text);
-            this.commands[command](args);
+            let spec = this.commands[command];
+            if (spec.echo) {
+                this.print(text);
+            }
+            spec.handler(args);
         } else {
             let helpStr = Object.keys(window.genlite.commands.commands).join(" ");
             this.print("invalid command\"" + command + "\". Options: " + helpStr);
         }
     }
 
-    public register(command: string, handler: (a: string) => void): boolean {
+    public register(
+        command: string,
+        handler: (a: string) => void,
+        help: any = null,
+        echo: boolean = true,
+    ): CommandSpec {
         if (command in this.commands || command.includes(" ")) {
-            // command is already registered
-            return false;
+            // command is already registered or invalid
+            return null;
         }
 
-        this.commands[command] = handler;
-        return true;
+        let spec : CommandSpec = null;
+        if (typeof help === 'function') {
+            spec = {
+                command: command,
+                handler: handler,
+                helpText: null,
+                helpFunction: help,
+                echo: echo,
+            };
+        } else if (typeof help === 'string') {
+            spec = {
+                command: command,
+                handler: handler,
+                helpText: help,
+                helpFunction: null,
+                echo: echo,
+            };
+        } else {
+            spec = {
+                command: command,
+                handler: handler,
+                helpText: null,
+                helpFunction: null,
+                echo: echo,
+            };
+        }
+
+        this.commands[command] = spec;
+        return spec;
+    }
+
+    public remove(command: string): boolean {
+        if (command in this.commands) {
+            delete this.commands[command];
+            return true;
+        }
+        return false;
     }
 
     public print(text: string) {
-        CHAT.addGameMessage(text);
+        // CHAT.addGameMessage assigns directly to innerHTML. To avoid any
+        // possible code injection, let text area do our string escaping.
+        let e = document.createElement('textarea');
+        e.textContent = text;
+        CHAT.addGameMessage(e.innerHTML);
     }
 
 }


### PR DESCRIPTION
a few features added to the commands plugin:
- remove(command: string) to allow plugins to unload their commands when disabled
- extra parameters when registering a command
  - help: string or function used with //help <command>
  - echo: boolean, disables echoing command string to chat
- commas between command list