### PR TITLE
Fix for tooltips, gathering recording, settings improved

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,4 +50,8 @@ import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand
     await genlite.pluginLoader.addPlugin(GenLiteSoundNotification);
     await genlite.pluginLoader.addPlugin(GenLiteGeneralChatCommands);
 
-})();
+    /** post init things */
+    await window.GenLiteSettingsPlugin.postInit();
+}
+)();
+

--- a/src/plugins/genlite-drop-recorder.plugin.ts
+++ b/src/plugins/genlite-drop-recorder.plugin.ts
@@ -51,12 +51,15 @@ export class GenLiteDropRecorderPlugin {
             this,  // context for handler
             "Warning!\n" + // Warning
             "Turning this setting on will send monster drop data along with your IP\u00A0address to an external server.\n\n" +
-            "Are you sure you want to enable this setting?"
+            "Are you sure you want to enable this setting?",
+            undefined,
+            "DropRecorder.Enable"
         );
     }
 
     handlePluginEnableDisable(state: boolean) {
         this.isPluginEnabled = state;
+
     }
 
     handleSubmitToServer(state: boolean) {

--- a/src/plugins/genlite-item-highlight.plugin.ts
+++ b/src/plugins/genlite-item-highlight.plugin.ts
@@ -27,9 +27,9 @@ export class GenLiteItemHighlightPlugin {
         this.item_highlight_div = document.createElement('div');
         this.item_highlight_div.className = 'item-indicators-list';
         document.body.appendChild(this.item_highlight_div);
-        this.isPluginEnabled = window.genlite.settings.add("ItemHighlight.Enable", true, "Highlight Items", "checkbox", this.handlePluginEnableDisable, this);
-        this.doCondenseItems = window.genlite.settings.add("CondenseItems.Enable", true, "Condence Items", "checkbox", this.handleCondeseEnableDisable, this);
-        let storedPriorityColor = window.genlite.settings.add("ItemHighlight.PriorityColor", "#ffa500", "Priority Item Color", "color", this.handleColorChange, this);
+        this.isPluginEnabled = window.genlite.settings.add("ItemHighlight.Enable", true, "Highlight Items", "checkbox", this.handlePluginEnableDisable, this, undefined, undefined);
+        this.doCondenseItems = window.genlite.settings.add("CondenseItems.Enable", true, "Condence Items", "checkbox", this.handleCondeseEnableDisable, this, undefined, undefined, "ItemHighlight.Enable");
+        let storedPriorityColor = window.genlite.settings.add("ItemHighlight.PriorityColor", "#ffa500", "Priority Item Color", "color", this.handleColorChange, this, undefined, undefined, "ItemHighlight.Enable");
 
         let sheet = document.styleSheets[0];
         this.styleRuleIndex = sheet.insertRule(`.genlite-priority-item { color: ${storedPriorityColor}; }`, sheet.cssRules.length);

--- a/src/plugins/genlite-menu-scaler.plugin.ts
+++ b/src/plugins/genlite-menu-scaler.plugin.ts
@@ -10,7 +10,7 @@ export class GenLiteMenuScaler {
         this.scaleList = {};
         this.isPluginEnabled = window.genlite.settings.add("MenuScaler.Enable", true, "MenuScaler", "checkbox", this.handlePluginEnableDisable, this);
         this.scaleList.rightClick = window.genlite.settings.add("MenuScalerRightCLick.1", true, "Scale Right Click Menu", "range", this.scaleRightClick, this, undefined,
-            [['min', '0.1'], ['max', '4'], ['step', '0.1'], ['value', '1']]);
+            [['min', '0.1'], ['max', '4'], ['step', '0.1'], ['value', '1']], "MenuScaler.Enable");
     }
 
     handlePluginEnableDisable(state: boolean) {

--- a/src/plugins/genlite-menuswapper.plugin.ts
+++ b/src/plugins/genlite-menuswapper.plugin.ts
@@ -15,7 +15,7 @@ export class GenLiteMenuSwapperPlugin {
 
         NPC.prototype.intersects = this.leftClickBankIntersects;
         OptimizedScene.prototype.intersects = this.sceneryIntersects;
-        
+
     }
 
 

--- a/src/plugins/genlite-npc-highlight.plugin.ts
+++ b/src/plugins/genlite-npc-highlight.plugin.ts
@@ -106,7 +106,6 @@ export class GenLiteNPCHighlightPlugin {
         /* look for start of combat set the curEnemy and record data */
         if (verb == "spawnObject" && payload.type == "combat" &&
             (payload.participant1 == PLAYER.id || payload.participant2 == PLAYER.id)) {
-            console.log(payload);
             this.curCombat = payload.id;
             let curCombat = GAME.combats[payload.id];
             this.curEnemy = curCombat.left.id == PLAYER.id ? curCombat.right.id : curCombat.left.id;

--- a/src/plugins/genlite-sound-notification.plugin.ts
+++ b/src/plugins/genlite-sound-notification.plugin.ts
@@ -8,9 +8,9 @@ export class GenLiteSoundNotification {
     async init() {
         window.genlite.registerModule(this);
         this.doHealthCheck = window.genlite.settings.add("LowHealth.Enable", false, "Low Health Sound", "checkbox", this.handleDoHealthCheck, this);
-                                                                                //this is a stupid ass thing but *shrug*
+        //this is a stupid ass thing but *shrug*
         this.healthThreshold = window.genlite.settings.add("LowHealth.0", 0, "Low Health Threshold: <div style=\"display: contents;\" id=\"GenLiteHealthThresholdOutput\"></div>", "range", this.setHealthThreshold, this, undefined,
-            [['min', '1'], ['max', '100'], ['step', '1'], ['value', '0']]);
+            [['min', '1'], ['max', '100'], ['step', '1'], ['value', '0']], "LowHealth.Enable");
         document.getElementById("GenLiteHealthThresholdOutput").innerText = ` ${this.healthThreshold}%`
     }
 


### PR DESCRIPTION
Disabling food tooltips no longer causes the ui to crash on refresh. Wanderer and Pacifist food tooltips added.
Added gathering recording to recipe recorder.
Settings are now grayed out if the master setting is disabled.