### PR TITLE
music selection plugin

### DIFF
--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -60,9 +60,15 @@ declare const MUSIC_PLAYER: {
     [key: string]: any,
 };
 
+declare const MUSIC_TRACK_NAMES: {
+    [key: string]: string,
+};
+
 declare const GRAPHICS: {
     [key: string]: any,
 };
+
+declare const SETTINGS: any;
 
 declare const PhasedLoadingManager: {
     [key: string]: any,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { GenLiteWikiDataCollectionPlugin } from "./plugins/genlite-wiki-data-col
 import { GenLiteXpCalculator } from "./plugins/genlite-xp-calculator.plugin";
 import { GenLiteHitRecorder } from "./plugins/genlite-hit-recorder.plugin";
 import { GenLiteMenuScaler } from "./plugins/genlite-menu-scaler.plugin";
+import { GenLiteMusicPlugin } from "./plugins/genlite-music.plugin";
 import { GenLiteLocationsPlugin } from "./plugins/genlite-locations.plugin";
 import { GenLiteMenuSwapperPlugin } from "./plugins/genlite-menuswapper.plugin";
 import { GenLiteItemTooltips } from "./plugins/genlite-item-tooltips.plugin";
@@ -44,6 +45,7 @@ import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand
     await genlite.pluginLoader.addPlugin(GenLiteRecipeRecorderPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteHitRecorder);
     await genlite.pluginLoader.addPlugin(GenLiteMenuScaler);
+    await genlite.pluginLoader.addPlugin(GenLiteMusicPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteLocationsPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteMenuSwapperPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteItemTooltips);

--- a/src/plugins/genlite-music.plugin.ts
+++ b/src/plugins/genlite-music.plugin.ts
@@ -1,5 +1,8 @@
 export class GenLiteMusicPlugin {
     static pluginName = 'GenLiteMusicPlugin';
+    static missingTracks = [
+        "snow-relax",
+    ];
 
     isPluginEnabled: boolean = false;
     originalSetTrack: Function;
@@ -37,19 +40,28 @@ export class GenLiteMusicPlugin {
 
         this.selectionMenu = <HTMLElement>document.createElement("div");
         this.selectionMenu.style.position = "fixed";
-        this.selectionMenu.style.border = "2px solid black";
         this.selectionMenu.style.right = "20px";
         this.selectionMenu.style.top = "20px";
+
         this.selectionMenu.style.height = "20em";
         this.selectionMenu.style.display = "flex";
         this.selectionMenu.style.flexDirection = "column";
+
+        this.selectionMenu.style.color = "#ffd593";
+        this.selectionMenu.style.borderTop = "2px solid #b54f08";
+        this.selectionMenu.style.borderLeft = "2px solid #572008";
+        this.selectionMenu.style.borderRight = "2px solid #572008";
+        this.selectionMenu.style.borderBottom = "2px solid #250801";
         this.selectionMenu.style.fontFamily = "acme,times new roman,Times,serif";
 
         let header = <HTMLElement>document.createElement("div");
         header.innerText = "Music Selection";
-        header.style.backgroundColor = "darkgray";
+        header.style.fontWeight = "bold";
         header.style.padding = "4px";
         header.style.textAlign = "center";
+        header.style.textShadow = "-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000";
+        header.style.backgroundColor = "#9c4209";
+        header.style.color = "#fdda2e";
         this.selectionMenu.appendChild(header);
 
         let container = <HTMLElement>document.createElement("div");
@@ -58,9 +70,12 @@ export class GenLiteMusicPlugin {
         this.selectionMenu.appendChild(container);
 
         for (const track in MUSIC_TRACK_NAMES) {
+            if (GenLiteMusicPlugin.missingTracks.includes(track)) {
+                continue;
+            }
             let name = MUSIC_TRACK_NAMES[track];
             let b = <HTMLElement>document.createElement("div");
-            b.style.backgroundColor = 'lightgray';
+            b.style.backgroundColor = '#461400';
             b.style.width = "100%";
             b.innerText = name;
             b.onclick = (e) => {
@@ -159,13 +174,13 @@ export class GenLiteMusicPlugin {
 
     setNextTrack(track: string) {
         if (this.currentSelection != null) {
-            this.currentSelection.style.backgroundColor = 'lightgray';
+            this.currentSelection.style.backgroundColor = '#461400';
         }
 
         var e = this.selectionOptions[track];
         if (e) {
             this.currentSelection = e;
-            e.style.backgroundColor = 'green';
+            e.style.backgroundColor = '#008000';
         }
 
         this.currentTrack = track;

--- a/src/plugins/genlite-music.plugin.ts
+++ b/src/plugins/genlite-music.plugin.ts
@@ -43,7 +43,7 @@ export class GenLiteMusicPlugin {
         this.selectionMenu.style.height = "20em";
         this.selectionMenu.style.display = "flex";
         this.selectionMenu.style.flexDirection = "column";
-        this.selectionMenu.style.fontFamily = "iacme,times new roman,Times,serif";
+        this.selectionMenu.style.fontFamily = "acme,times new roman,Times,serif";
 
         let header = <HTMLElement>document.createElement("div");
         header.innerText = "Music Selection";

--- a/src/plugins/genlite-music.plugin.ts
+++ b/src/plugins/genlite-music.plugin.ts
@@ -1,0 +1,182 @@
+export class GenLiteMusicPlugin {
+    static pluginName = 'GenLiteMusicPlugin';
+
+    isPluginEnabled: boolean = false;
+    originalSetTrack: Function;
+
+    selectionMenu: HTMLElement;
+    displayed = false;
+
+    selectionOptions: {[key: string]: HTMLElement} = {};
+    currentSelection: HTMLElement = null;
+
+    // plugin modes
+    //   passthrough - default genfanad music
+    //   manual      - manual select and repeat song
+    //   shuffle     - change song every 3 min
+    musicMode: "passthrough" | "manual" | "shuffle" = "passthrough";
+
+    // save state when enabling shuffle
+    previousMode: "passthrough" | "manual" = "passthrough";
+    shuffleTimeout = 0;
+
+    currentTrack = "";
+
+    async init() {
+        window.genlite.registerModule(this);
+        this.originalSetTrack = MUSIC_PLAYER.setNextTrack;
+
+        this.isPluginEnabled = window.genlite.settings.add(
+            "MusicPlugin.Enable",
+            false,
+            "Music Selection",
+            "checkbox",
+            this.handlePluginEnableDisable,
+            this
+        );
+
+        this.selectionMenu = <HTMLElement>document.createElement("div");
+        this.selectionMenu.style.position = "fixed";
+        this.selectionMenu.style.border = "2px solid black";
+        this.selectionMenu.style.right = "20px";
+        this.selectionMenu.style.top = "20px";
+        this.selectionMenu.style.height = "20em";
+        this.selectionMenu.style.display = "flex";
+        this.selectionMenu.style.flexDirection = "column";
+        this.selectionMenu.style.fontFamily = "iacme,times new roman,Times,serif";
+
+        let header = <HTMLElement>document.createElement("div");
+        header.innerText = "Music Selection";
+        header.style.backgroundColor = "darkgray";
+        header.style.padding = "4px";
+        header.style.textAlign = "center";
+        this.selectionMenu.appendChild(header);
+
+        let container = <HTMLElement>document.createElement("div");
+        container.style.overflow = "scroll";
+        container.style.width = "100%";
+        this.selectionMenu.appendChild(container);
+
+        for (const track in MUSIC_TRACK_NAMES) {
+            let name = MUSIC_TRACK_NAMES[track];
+            let b = <HTMLElement>document.createElement("div");
+            b.style.backgroundColor = 'lightgray';
+            b.style.width = "100%";
+            b.innerText = name;
+            b.onclick = (e) => {
+                if (this.musicMode != "shuffle") {
+                    this.musicMode = "manual";
+                } else if (this.shuffleTimeout != 0) {
+                    clearTimeout(this.shuffleTimeout);
+                    this.shuffleTimeout = window.setTimeout(this.nextShuffle, 1 * 60 * 1000);
+                }
+
+                SETTINGS.setMusicTrackText("Transitioning...");
+                this.setNextTrack(track);
+            };
+
+            container.appendChild(b);
+            this.selectionOptions[track] = b;
+        }
+    }
+
+    handlePluginEnableDisable(state: boolean) {
+        this.isPluginEnabled = state;
+        this.updateMusicUI();
+    }
+
+    initializeUI() {
+        this.updateMusicUI();
+    }
+
+    updateMusicUI() {
+        if (this.isPluginEnabled) {
+            MUSIC_PLAYER.setNextTrack = (t) => {
+                if (this.musicMode == "passthrough") {
+                    this.setNextTrack(t);
+                }
+            };
+            SETTINGS.DOM_music_text.onclick = (e) => {
+                this.toggleDisplay();
+            };
+        } else {
+            MUSIC_PLAYER.setNextTrack = this.originalSetTrack;
+            SETTINGS.DOM_music_text.onclick = (e) => {};
+            this.hideMusicSelection();
+        }
+    }
+
+    enableShuffle() {
+        if (this.musicMode != "shuffle") {
+            this.previousMode = this.musicMode;
+            this.musicMode = "shuffle";
+            this.nextShuffle();
+        }
+    }
+
+    disableShuffle() {
+        if (this.musicMode == "shuffle") {
+            this.musicMode = this.previousMode;
+        }
+    }
+
+    nextShuffle() {
+        if (this.musicMode == "shuffle") {
+            var choices = Object.keys(this.selectionOptions);
+            var track = choices[Math.floor(Math.random() * choices.length)];
+            this.setNextTrack(track);
+            this.shuffleTimeout = window.setTimeout(this.nextShuffle, 1 * 60 * 1000);
+        }
+    }
+
+    logoutOK() {
+        this.hideMusicSelection();
+    }
+
+    loginOK() {
+        switch (this.musicMode) {
+            case "passthrough":
+                break;
+            case "manual":
+                if (this.currentTrack) {
+                    this.setNextTrack(this.currentTrack);
+                }
+            case "shuffle":
+                this.nextShuffle();
+        }
+    }
+
+    setNextTrack(track: string) {
+        if (this.currentSelection != null) {
+            this.currentSelection.style.backgroundColor = 'lightgray';
+        }
+
+        var e = this.selectionOptions[track];
+        if (e) {
+            this.currentSelection = e;
+            e.style.backgroundColor = 'green';
+        }
+
+        this.currentTrack = track;
+        this.originalSetTrack.call(MUSIC_PLAYER, track);
+    }
+
+    toggleDisplay() {
+        if (this.displayed) {
+            this.hideMusicSelection();
+        } else {
+            this.displayMusicSelection();
+        }
+    }
+
+    displayMusicSelection() {
+        document.body.appendChild(this.selectionMenu);
+        this.displayed = true;
+    }
+
+    hideMusicSelection() {
+        this.selectionMenu.remove();
+        this.displayed = false;
+    }
+
+}


### PR DESCRIPTION
Plugin allows player to change currently playing music.

The plugin is used in two ways:
- clicking the currently song name in settings opens a song selection window
- the //music chat command

The music command provides a few extra functions:
- "list" all the available tracks
- "play" a track
- "shuffle" to change song every 3 minutes
- "default" to restore default music