### PR TITLE
chat plugin, inventory plugin, fog level, and item highlight

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
 import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
 import { GenLiteChatPlugin } from "./plugins/genlite-chat.plugin";
 import { GenLiteDropRecorderPlugin } from "./plugins/genlite-drop-recorder.plugin";
+import { GenLiteInventoryPlugin } from "./plugins/genlite-inventory.plugin";
 import { GenLiteItemHighlightPlugin } from "./plugins/genlite-item-highlight.plugin";
 import { GenLiteNPCHighlightPlugin } from "./plugins/genlite-npc-highlight.plugin";
 import { GenLiteRecipeRecorderPlugin } from "./plugins/genlite-recipe-recorder.plugin";
@@ -40,7 +41,8 @@ import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand
     await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteChatPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteNPCHighlightPlugin);
-    //await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
+    await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
+    await genlite.pluginLoader.addPlugin(GenLiteInventoryPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteDropRecorderPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteWikiDataCollectionPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteXpCalculator);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
 
 /** Official Plugins */
 import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
+import { GenLiteChatPlugin } from "./plugins/genlite-chat.plugin";
 import { GenLiteDropRecorderPlugin } from "./plugins/genlite-drop-recorder.plugin";
 import { GenLiteItemHighlightPlugin } from "./plugins/genlite-item-highlight.plugin";
 import { GenLiteNPCHighlightPlugin } from "./plugins/genlite-npc-highlight.plugin";
@@ -37,6 +38,7 @@ import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand
 
     /** Official Plugins */
     await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);
+    await genlite.pluginLoader.addPlugin(GenLiteChatPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteNPCHighlightPlugin);
     //await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
     await genlite.pluginLoader.addPlugin(GenLiteDropRecorderPlugin);

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -1,0 +1,62 @@
+export class GenLiteChatPlugin {
+    static pluginName = 'GenLiteChatPlugin';
+
+    static gameMessagesToIgnore: Set<string> = new Set<string>([
+        "You start mining the rock.",
+        "You fail to get some ore.",
+        "You get some ore.",
+        "You stop mining the rock.",
+        "The rock is out of ore.",
+    ]);
+
+    filterGameMessages: boolean = false;
+    originalGameMessage: Function;
+
+    async init() {
+        window.genlite.registerModule(this);
+        this.filterGameMessages = window.genlite.settings.add(
+            "Chat.FilterGameMessages",
+            false,
+            "Filter Game Chat",
+            "checkbox",
+            this.handleFilterGameMessages,
+            this
+        );
+    }
+
+    public loginOK() {
+        this.originalGameMessage = CHAT.addGameMessage;
+        this.updateState();
+    }
+
+    handleFilterGameMessages(state: boolean) {
+        this.filterGameMessages = state;
+        this.updateState();
+    }
+
+    updateState() {
+        if (this.filterGameMessages) {
+            CHAT.addGameMessage = this.newGameMessage.bind(
+                CHAT,
+                this.originalGameMessage
+            );
+        } else {
+            CHAT.addGameMessage = this.originalGameMessage;
+        }
+    }
+
+    newGameMessage(original, text) {
+        if (!GenLiteChatPlugin.gameMessagesToIgnore.has(text)) {
+            original.bind(this)(text);
+        }
+    }
+
+    ignoreGameMessage(text) {
+        GenLiteChatPlugin.gameMessagesToIgnore.add(text);
+    }
+
+    stopIgnoringGameMessage(text) {
+        GenLiteChatPlugin.gameMessagesToIgnore.delete(text);
+    }
+
+}

--- a/src/plugins/genlite-inventory.plugin.ts
+++ b/src/plugins/genlite-inventory.plugin.ts
@@ -1,0 +1,45 @@
+export class GenLiteInventoryPlugin {
+    static pluginName = 'GenLiteInventoryPlugin';
+
+    disableDragOnShift: boolean = false;
+
+    async init() {
+        window.genlite.registerModule(this);
+        this.disableDragOnShift = window.genlite.settings.add(
+            "Inventory.ShiftDisableDrag",
+            true,
+            "Disable Dragging w/ Shift",
+            "checkbox",
+            this.handleDisableDrag,
+            this
+        );
+    }
+
+    public loginOK() {
+        this.updateState();
+    }
+
+    handleDisableDrag(state: boolean) {
+        this.disableDragOnShift = state;
+        this.updateState();
+    }
+
+    updateState() {
+        if (this.disableDragOnShift) {
+            for (const i in INVENTORY.DOM_slots) {
+                let slot = INVENTORY.DOM_slots[i];
+                slot.item_div.onmousedown = function (e) {
+                    if (e.shiftKey) {
+                        e.preventDefault();
+                    }
+                }
+            }
+        } else {
+            for (const i in INVENTORY.DOM_slots) {
+                let slot = INVENTORY.DOM_slots[i];
+                slot.item_div.onmousedown = function (e) {};
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
a bunch of changes here:

- re-enable item highlight plugin, fixed for v0.117
- add a slider for amount of fog (camera plugin)
- new chat plugin, disabled by default, filters out spammy game chat messages like mining ore, etc. Ideally players can tune their settings to only show game messages they care about (trade requests, levels) but ignore others.
- new inventory plugin, disables dragging items while holding shift