### PR TITLE
feat: changed the plugin execution to catch errors

### DIFF
--- a/src/core/genlite-plugin-loader.class.ts
+++ b/src/core/genlite-plugin-loader.class.ts
@@ -1,4 +1,5 @@
 import { ExamplePlugin } from "./help/example-plugin.class";
+import {GenLitePlugin} from './interfaces/plugin.interface';
 
 export class GenLitePluginLoader {
     plugins;
@@ -15,24 +16,27 @@ export class GenLitePluginLoader {
      * @param pluginClass
      * @returns {Promise<boolean>}
      */
-    async addPlugin(pluginClass) {
+    async addPlugin<T extends GenLitePlugin>(pluginClass): Promise<T> {
         try {
             this.verifyPluginClassStructure(pluginClass);
         } catch (e) {
             console.error('[GenLitePluginLoader]: Error loading plugin:', e);
             console.error('[GenLitePluginLoader]: Plugin classes need to follow the given example structure', this.getExampleStructure());
-            return false;
+            return undefined;
         }
 
-        const pluginInstance = new pluginClass();
-        await pluginInstance.init();
+        try {
+            const pluginInstance = new pluginClass();
+            await pluginInstance.init();
 
-        window[pluginClass.pluginName] = pluginInstance;
+            window[pluginClass.pluginName] = pluginInstance;
 
-        this.plugins.push(pluginInstance);
-        console.log(`[GenLitePluginLoader]: Loaded plugin ${pluginClass.pluginName}`);
-
-        return window[pluginClass.pluginName];
+            this.plugins.push(pluginInstance);
+            console.log(`[GenLitePluginLoader]: Loaded plugin ${pluginClass.pluginName}`);
+            return pluginInstance;
+        } catch (e) {
+            console.error(`[GenLitePluginLoader]: Error initialising plugin ${pluginClass.pluginName}`, e);
+        }
     }
 
     /**

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -43,7 +43,7 @@ export class GenLite {
                 try {
                     module[fnName].apply(module, args);
                 } catch (e) {
-                    console.error(`GenLite plugin ${module.name} error in ${fnName}:`, e);
+                    console.error(`GenLite plugin ${module.constructor.pluginName} error in ${fnName}:`, e);
                 }
             }
         }

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -2,13 +2,14 @@ import { GenLitePluginLoader } from "./genlite-plugin-loader.class";
 import { GenLiteNotificationPlugin } from "./plugins/genlite-notification.plugin";
 import { GenLiteSettingsPlugin } from "./plugins/genlite-settings.plugin";
 import { GenLiteCommandsPlugin } from "./plugins/genlite-commands.plugin";
+import {GenLitePlugin} from './interfaces/plugin.interface';
 
 export class GenLite {
     static pluginName = 'GenLite';
 
-    pluginLoader;
+    pluginLoader: GenLitePluginLoader;
 
-    moduleList = [];
+    pluginList = [];
 
     notifications: GenLiteNotificationPlugin;
     settings: GenLiteSettingsPlugin;
@@ -22,139 +23,58 @@ export class GenLite {
     }
 
     async init() {
-        this.installHook(Camera.prototype, 'update', this.hook_Camera_update, this);
-        this.installHook(Network.prototype, 'logoutOK', this.hook_Network_logoutOK, this);
-        this.installHook(PhasedLoadingManager.prototype, 'start_phase', this.hook_PhasedLoadingManager_start_phase, this);
-        this.installHook(Network.prototype, 'action', this.hook_Network_action, this);
-        this.installHook(Network.prototype, 'handle', this.hook_Network_handle, this);
-        this.installHook(PlayerInfo.prototype, 'updateXP', this.hook_PlayerInfo_updateXP, this);
-        this.installHook(PlayerInfo.prototype, 'updateTooltip', this.hook_PlayerInfo_updateTooltip, this);
-        this.installHook(PlayerInfo.prototype, 'updateSkills', this.hook_PlayerInfo_updateSkills, this);
-        this.installHook(window, 'initializeUI', this.hook_window_initializeUI, this);
-        this.installHook(Game.prototype, 'combatUpdate', this.hook_Game_combatUpdate, this);
-        this.installHook(PlayerHUD.prototype, 'setHealth', this.hook_PlayerHUD_setHealth, this);
-        this.installHook(Inventory.prototype, 'handleUpdatePacket', this.hook_Inventory_handleUpdatePacket, this);
-
+        this.installHook(Camera.prototype, 'update');
+        this.installHook(Network.prototype, 'logoutOK');
+        this.installHook(PhasedLoadingManager.prototype, 'start_phase', this.hookPhased);
+        this.installHook(Network.prototype, 'action');
+        this.installHook(Network.prototype, 'handle');
+        this.installHook(PlayerInfo.prototype, 'updateXP');
+        this.installHook(PlayerInfo.prototype, 'updateTooltip');
+        this.installHook(PlayerInfo.prototype, 'updateSkills');
+        this.installHook(window, 'initializeUI');
+        this.installHook(Game.prototype, 'combatUpdate');
+        this.installHook(PlayerHUD.prototype, 'setHealth');
+        this.installHook(Inventory.prototype, 'handleUpdatePacket');
     }
 
-    hook_Camera_update() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].update === 'function') {
-                this.moduleList[i].update.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-
-    hook_Network_logoutOK() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].logoutOK === 'function') {
-                this.moduleList[i].logoutOK.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-
-    hook_Network_action() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].action === 'function') {
-                this.moduleList[i].action.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-
-    hook_Network_handle() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].handle === 'function') {
-                this.moduleList[i].handle.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-
-    hook_PhasedLoadingManager_start_phase(phase) {
-        if (phase === "game_loaded") {
-            for (var i = 0; i < this.moduleList.length; i++) {
-                if (typeof this.moduleList[i].loginOK === 'function') {
-                    this.moduleList[i].loginOK.apply(this.moduleList[i], arguments);
+    hook(fnName: string, ...args: Array<unknown>) {
+        for (const module of this.pluginList) {
+            if (typeof module[fnName] === 'function') {
+                try {
+                    module[fnName].apply(module, args);
+                } catch (e) {
+                    console.error(`GenLite plugin ${module.name} error in ${fnName}:`, e);
                 }
             }
         }
     }
 
-    hook_PlayerInfo_updateXP() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].updateXP === 'function') {
-                this.moduleList[i].updateXP.apply(this.moduleList[i], arguments);
-            }
+    hookPhased(fnName: string, ...args: Array<unknown>) {
+        if (args[0] === "game_loaded") {
+            this.hook('loginOK', args);
         }
     }
 
-    hook_PlayerInfo_updateTooltip() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].updateTooltip === 'function') {
-                this.moduleList[i].updateTooltip.apply(this.moduleList[i], arguments);
-            }
+    registerPlugin(plugin: GenLitePlugin) {
+        this.pluginList.push(plugin);
+    }
+
+    unregisterPlugin(plugin: GenLitePlugin) {
+        const index = this.pluginList.indexOf(plugin);
+
+        if (index !== -1) {
+            this.pluginList.splice(index, 1);
         }
     }
 
-    hook_PlayerInfo_updateSkills() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].updateSkills === 'function') {
-                this.moduleList[i].updateSkills.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
+    installHook(object: Object, functionName: string, hookFn = this.hook) {
+        const self = this;
 
-
-    hook_window_initializeUI() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].initializeUI === 'function') {
-                this.moduleList[i].initializeUI.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-    hook_Game_combatUpdate() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].combatUpdate === 'function') {
-                this.moduleList[i].combatUpdate.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-
-    hook_PlayerHUD_setHealth() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].setHealth === 'function') {
-                this.moduleList[i].setHealth.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-
-    hook_Inventory_handleUpdatePacket() {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (typeof this.moduleList[i].handleUpdatePacket === 'function') {
-                this.moduleList[i].handleUpdatePacket.apply(this.moduleList[i], arguments);
-            }
-        }
-    }
-
-    registerModule(module) {
-        this.moduleList[this.moduleList.length] = module;
-    }
-
-    unregisterModule(module) {
-        for (var i = 0; i < this.moduleList.length; i++) {
-            if (this.moduleList[i] === module) {
-                this.moduleList.splice(i, 1);
-                break;
-            }
-        }
-    }
-
-    installHook(object, functionName, callback, callback_this) {
         (function (originalFunction) {
-            object[functionName] = function () {
-                var returnValue = originalFunction.apply(this, arguments);
-                if (callback !== undefined) {
-                    callback.apply(callback_this ?? this, arguments);
-                }
+            object[functionName] = function (...args: Array<unknown>) {
+                const returnValue = originalFunction.apply(this, arguments);
+
+                hookFn.apply(self, [functionName, ...args]);
 
                 return returnValue;
             };
@@ -162,7 +82,7 @@ export class GenLite {
     }
 
     sendDataToServer(url, data) {
-        var xmlhttp = new XMLHttpRequest();
+        const xmlhttp = new XMLHttpRequest();
         xmlhttp.open("POST", `https://nextgensoftware.nl/${url}.php`);
         xmlhttp.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
         xmlhttp.send(JSON.stringify(data));

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -1,7 +1,7 @@
 /** Browser globals */
 declare interface Window {
     [key: string]: any,
-};
+}
 
 declare interface CommandSpec {
     command: string,
@@ -9,7 +9,7 @@ declare interface CommandSpec {
     helpFunction: (a: string) => string,
     helpText: string,
     echo: boolean,
-};
+}
 
 declare const ITEM_RIGHTCLICK_LIMIT: number;
 
@@ -126,7 +126,7 @@ declare const KEYBOARD: {
 }
 
 declare class SFXPlayer {
-};
+}
 
 declare const Inventory: {
     [key: string]: any,

--- a/src/core/help/example-plugin.class.ts
+++ b/src/core/help/example-plugin.class.ts
@@ -1,4 +1,6 @@
-export class ExamplePlugin {
+import {GenLitePlugin} from '../interfaces/plugin.interface';
+
+export class ExamplePlugin implements GenLitePlugin {
     static pluginName = 'My Plugin';
     async init() {}
 }

--- a/src/core/interfaces/plugin.interface.ts
+++ b/src/core/interfaces/plugin.interface.ts
@@ -1,0 +1,15 @@
+export interface GenLitePlugin {
+    init: () => Promise<void>,
+    loginOK?: () => void,
+    logoutOK?: () => void,
+    action?: (verb: string, params: any) => void // TODO: provide proper type
+    handle?: (verb: string, payload: any) => void,
+    update?: (dt: number) => void,
+    updateXP?: (xp: any) => void, // TODO: provide proper type
+    updateTooltip?: () => void,
+    updateSkills?: () => void,
+    initializeUI?: () => void,
+    combatUpdate?: (update: any) => void,
+    setHealth?: (current: number, max: number) => void,
+    handleUpdatePacket?: (packet: any) => void,
+}

--- a/src/core/plugins/genlite-commands.plugin.ts
+++ b/src/core/plugins/genlite-commands.plugin.ts
@@ -6,7 +6,7 @@ export class GenLiteCommandsPlugin {
     private originalProcessInput: Function;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
 
         this.originalProcessInput = Chat.prototype.processInput;
         this.register("help", function (s) {

--- a/src/plugins/genlite-camera.plugin.ts
+++ b/src/plugins/genlite-camera.plugin.ts
@@ -6,9 +6,9 @@ import {
     SkyboxUriBack,
     SkyboxUriFront,
 } from "./skybox-data";
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
 
-
-export class GenLiteCameraPlugin {
+export class GenLiteCameraPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteCameraPlugin';
 
     static minRenderDistance = 40;
@@ -33,7 +33,7 @@ export class GenLiteCameraPlugin {
     skybox: any = null;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
 
         this.originalCameraMode = WorldManager.prototype.updatePlayerTile;
 

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteChatPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteChatPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteChatPlugin';
 
     static gameMessagesToIgnore: Set<string> = new Set<string>([
@@ -13,7 +15,7 @@ export class GenLiteChatPlugin {
     originalGameMessage: Function;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.filterGameMessages = window.genlite.settings.add(
             "Chat.FilterGameMessages",
             false,

--- a/src/plugins/genlite-drop-recorder.plugin.ts
+++ b/src/plugins/genlite-drop-recorder.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteDropRecorderPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteDropRecorderPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteDropRecorderPlugin';
 
     monsterData = {
@@ -29,7 +31,7 @@ export class GenLiteDropRecorderPlugin {
     submitItemsToServer: boolean = false;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         let dropTableString = localStorage.getItem("genliteDropTable")
         if (dropTableString == null) {
             this.dropTable = {};

--- a/src/plugins/genlite-generalchatcommand.plugin.ts
+++ b/src/plugins/genlite-generalchatcommand.plugin.ts
@@ -1,14 +1,16 @@
-export class GenLiteGeneralChatCommands {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteGeneralChatCommands implements GenLitePlugin {
     static pluginName = 'GenLiteGeneralChatCommands';
 
     loginTime: number = 0;
     playedTime: number = 0; // this is a running counter not a date
     timeSinceLastSave: number = 0;
 
-    playedSaveInverval: NodeJS.Timer;;
+    playedSaveInverval: NodeJS.Timer;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
 
         let playedString = localStorage.getItem("genlitePlayed")
         if (playedString == null) {

--- a/src/plugins/genlite-hit-recorder.plugin.ts
+++ b/src/plugins/genlite-hit-recorder.plugin.ts
@@ -1,3 +1,5 @@
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
 class HitInfo {
     //this needs to be moved to an interface once i figure out how TS interfaces work
     hitList = {};
@@ -20,7 +22,7 @@ class HitInfo {
     entropy = 0;
 }
 
-export class GenLiteHitRecorder {
+export class GenLiteHitRecorder implements GenLitePlugin {
     static pluginName = 'GenLiteHitRecorder';
 
     curEnemy: { [key: string]: any } = undefined;
@@ -71,7 +73,7 @@ export class GenLiteHitRecorder {
     }
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.isPluginEnabled = window.genlite.settings.add("HitRecorder.Enable", true, "Hit Recorder", "checkbox", this.handlePluginEnableDisable, this);
         this.dpsOverlayContainer.appendChild(this.dpsOverlay);
     }

--- a/src/plugins/genlite-inventory.plugin.ts
+++ b/src/plugins/genlite-inventory.plugin.ts
@@ -1,10 +1,12 @@
-export class GenLiteInventoryPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteInventoryPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteInventoryPlugin';
 
     disableDragOnShift: boolean = false;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.disableDragOnShift = window.genlite.settings.add(
             "Inventory.ShiftDisableDrag",
             true,

--- a/src/plugins/genlite-item-highlight.plugin.ts
+++ b/src/plugins/genlite-item-highlight.plugin.ts
@@ -37,7 +37,9 @@ interface Element {
  * to each item, modifying the left-click and right-click actions order.
 */
 
-export class GenLiteItemHighlightPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteItemHighlightPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteItemHighlightPlugin';
 
     originalItemStackIntersects: Function;
@@ -57,7 +59,7 @@ export class GenLiteItemHighlightPlugin {
     hideLables: boolean = false;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.originalItemStackIntersects = ItemStack.prototype.intersects;
 
         this.loadItemList();
@@ -378,7 +380,7 @@ export class GenLiteItemHighlightPlugin {
     // update loop
     //
 
-    update(dt) {
+    update() {
         if (this.isPluginEnabled && this.render) {
             this.updateTrackedStacks();
             this.updateElements();

--- a/src/plugins/genlite-item-tooltips.plugin.ts
+++ b/src/plugins/genlite-item-tooltips.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteItemTooltips {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteItemTooltips implements GenLitePlugin {
     static pluginName = 'GenLiteItemTooltips';
 
     itemToolTip: HTMLElement;
@@ -14,7 +16,7 @@ export class GenLiteItemTooltips {
     isValueEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
 
         this.isPluginEnabled = window.genlite.settings.add("ItemToolTips.Enable", true, "Tooltips", "checkbox", this.handlePluginEnableDisable, this);
         this.isFoodEnabled = window.genlite.settings.add("FoodToolTips.Enable", true, "Food Tooltips", "checkbox", this.handleFoodEnableDisable, this, undefined, undefined, "ItemToolTips.Enable");

--- a/src/plugins/genlite-locations.plugin.ts
+++ b/src/plugins/genlite-locations.plugin.ts
@@ -4,7 +4,9 @@
  Known Issues:
  */
 
-export class GenLiteLocationsPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteLocationsPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteLocationsPlugin'
     private classifyPoint = require("robust-point-in-polygon")
     private stylesheetAdded: boolean
@@ -128,7 +130,7 @@ export class GenLiteLocationsPlugin {
         document.body.appendChild(this.mapIframe)
     }
     async init() {
-        window.genlite.registerModule(this)
+        window.genlite.registerPlugin(this)
 
 
 

--- a/src/plugins/genlite-menu-scaler.plugin.ts
+++ b/src/plugins/genlite-menu-scaler.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteMenuScaler {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteMenuScaler implements GenLitePlugin {
     static pluginName = 'GenLiteMenuScaler';
 
     scaleList;
@@ -6,7 +8,7 @@ export class GenLiteMenuScaler {
     isPluginEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.scaleList = {};
         this.isPluginEnabled = window.genlite.settings.add("MenuScaler.Enable", true, "MenuScaler", "checkbox", this.handlePluginEnableDisable, this);
         this.scaleList.rightClick = window.genlite.settings.add("MenuScalerRightCLick.1", true, "Scale Right Click Menu", "range", this.scaleRightClick, this, undefined,
@@ -39,4 +41,6 @@ export class GenLiteMenuScaler {
         let menu = document.getElementById("new_ux-contextual-menu-modal");
         menu.style.transform = `scale(${this.scaleList.rightClick})`;
     }
+
+
 }

--- a/src/plugins/genlite-menuswapper.plugin.ts
+++ b/src/plugins/genlite-menuswapper.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteMenuSwapperPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteMenuSwapperPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteMenuSwapperPlugin';
 
     useOneClickBank: boolean = false;
@@ -10,7 +12,7 @@ export class GenLiteMenuSwapperPlugin {
 
     intersect_vector = new THREE.Vector3();
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
 
         this.useOneClickBank = window.genlite.settings.add("NPCMenuSwapper.LeftClickBank", true, "Left Click Bank", "checkbox", this.handleLeftClickBankToggle, this);
         this.useOneClickTrade = window.genlite.settings.add("NPCMenuSwapper.LeftClickTrade", true, "Left Click Trade", "checkbox", this.handleLeftClickTradeToggle, this);

--- a/src/plugins/genlite-music.plugin.ts
+++ b/src/plugins/genlite-music.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteMusicPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteMusicPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteMusicPlugin';
     static missingTracks = [
         "snow-relax",
@@ -26,7 +28,7 @@ export class GenLiteMusicPlugin {
     currentTrack = "";
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.originalSetTrack = MUSIC_PLAYER.setNextTrack;
 
         this.isPluginEnabled = window.genlite.settings.add(

--- a/src/plugins/genlite-npc-highlight.plugin.ts
+++ b/src/plugins/genlite-npc-highlight.plugin.ts
@@ -1,6 +1,8 @@
 import { GenLiteWikiDataCollectionPlugin } from "./genlite-wiki-data-collection.plugin";
 
-export class GenLiteNPCHighlightPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteNPCHighlightPlugin';
     static healthListVersion = "2"
 
@@ -24,7 +26,7 @@ export class GenLiteNPCHighlightPlugin {
 
     packList;
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
 
         this.npc_highlight_div = document.createElement('div');
         this.npc_highlight_div.className = 'npc-indicators-list';

--- a/src/plugins/genlite-recipe-recorder.plugin.ts
+++ b/src/plugins/genlite-recipe-recorder.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteRecipeRecorderPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteRecipeRecorderPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteRecipeRecorderPlugin';
 
     isCrafting = false;
@@ -18,7 +20,7 @@ export class GenLiteRecipeRecorderPlugin {
     isPluginEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         let dropTableString = localStorage.getItem("GenliteRecipeRecorder")
         if (dropTableString == null) {
             this.recipeResults = {};

--- a/src/plugins/genlite-sound-notification.plugin.ts
+++ b/src/plugins/genlite-sound-notification.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteSoundNotification {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteSoundNotification implements GenLitePlugin {
     static pluginName = 'GenLiteSoundNotification';
 
     doHealthCheck: boolean = false;
@@ -17,7 +19,7 @@ export class GenLiteSoundNotification {
 
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.doHealthCheck = window.genlite.settings.add("LowHealth.Enable", false, "Low Health Sound", "checkbox", this.handleDoHealthCheck, this);
         //this is a stupid ass thing but *shrug*
         this.healthThreshold = window.genlite.settings.add("LowHealth.0", 0, "Low Health Threshold: <div style=\"display: contents;\" id=\"GenLiteHealthThresholdOutput\"></div>", "range", this.setHealthThreshold, this, undefined,

--- a/src/plugins/genlite-wiki-data-collection.plugin.ts
+++ b/src/plugins/genlite-wiki-data-collection.plugin.ts
@@ -14,7 +14,9 @@ class MonsterData {
     "Version" = 3;
 }
 
-export class GenLiteWikiDataCollectionPlugin {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteWikiDataCollectionPlugin';
 
     previously_seen = {};
@@ -33,7 +35,7 @@ export class GenLiteWikiDataCollectionPlugin {
     sendInterval;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
 
         this.isPluginEnabled = window.genlite.settings.add(
             "WikiDataColl.Enable",

--- a/src/plugins/genlite-xp-calculator.plugin.ts
+++ b/src/plugins/genlite-xp-calculator.plugin.ts
@@ -1,4 +1,6 @@
-export class GenLiteXpCalculator {
+import {GenLitePlugin} from '../core/interfaces/plugin.interface';
+
+export class GenLiteXpCalculator implements GenLitePlugin {
     static pluginName = 'GenLiteXpCalculatorPlugin';
 
     skillsList = {
@@ -42,7 +44,7 @@ export class GenLiteXpCalculator {
     isPluginEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerModule(this);
+        window.genlite.registerPlugin(this);
         this.resetCalculatorAll();
         this.isPluginEnabled = window.genlite.settings.add("XPCalculator.Enable", true, "XP Calculator", "checkbox", this.handlePluginEnableDisable, this);
     }


### PR DESCRIPTION
- I've made the plugin execution safe so any Genfanad update that breaks a plugin should not freeze your browser anymore.
- Additionally I've provided a plugin interface with all available functions, this should help new developers as code completion will ba available. I've documented these functions to reflect the current usage, but this should be expanded in the future.
- Lastly I've refactored the hooking mechanism to make it more DRY and cleaned up some names so they're more consistent e.g. module <> plugin

I am fully aware that I might've gone a bit overboard, so please provide feedback if you disagree with any of my changes.

Example error:
![image](https://user-images.githubusercontent.com/5339851/221003577-611e2063-e82d-4a36-bb77-726ac5307fb3.png)
