### PR TITLE
indexeddb + chat plugin features + interfaces + warning style

### DIFF
--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -16,7 +16,7 @@ import { GenLiteNotificationPlugin } from "./plugins/genlite-notification.plugin
 import { GenLiteSettingsPlugin } from "./plugins/genlite-settings.plugin";
 import { GenLiteCommandsPlugin } from "./plugins/genlite-commands.plugin";
 import { GenLiteDatabasePlugin } from "./plugins/genlite-database.plugin";
-import {GenLitePlugin} from './interfaces/plugin.interface';
+import { GenLitePlugin } from './interfaces/plugin.interface';
 
 export class GenLite {
     static pluginName = 'GenLite';

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -15,7 +15,8 @@ import { GenLitePluginLoader } from "./genlite-plugin-loader.class";
 import { GenLiteNotificationPlugin } from "./plugins/genlite-notification.plugin";
 import { GenLiteSettingsPlugin } from "./plugins/genlite-settings.plugin";
 import { GenLiteCommandsPlugin } from "./plugins/genlite-commands.plugin";
-import { GenLitePlugin } from './interfaces/plugin.interface';
+import { GenLiteDatabasePlugin } from "./plugins/genlite-database.plugin";
+import {GenLitePlugin} from './interfaces/plugin.interface';
 
 export class GenLite {
     static pluginName = 'GenLite';
@@ -27,6 +28,7 @@ export class GenLite {
     notifications: GenLiteNotificationPlugin;
     settings: GenLiteSettingsPlugin;
     commands: GenLiteCommandsPlugin;
+    database: GenLiteDatabasePlugin;
 
     /** We allow setting "any field, to anything" in order to load core features such as genlite.notifications */
     [key: string]: any;

--- a/src/core/helpers/genlite-confirmation.class.ts
+++ b/src/core/helpers/genlite-confirmation.class.ts
@@ -16,7 +16,7 @@ export class GenLiteConfirmation {
         return window.confirm(message);
     }
 
-    static async confirmModal(message: string[], callback: () => void) {
+    static confirmModal(message: string[], callback: () => void) {
         let bg = document.createElement('div');
         bg.style.height = '100%';
         bg.style.width = '100%';
@@ -84,8 +84,9 @@ export class GenLiteConfirmation {
         modal.appendChild(body);
 
         let scrollBox = document.createElement('div');
-        scrollBox.style.width = '100%';
+        scrollBox.style.width = '90%';
         scrollBox.style.height = '75%';
+        scrollBox.style.margin = 'auto';
         scrollBox.style.overflowY = 'scroll';
         body.appendChild(scrollBox);
 

--- a/src/core/helpers/genlite-confirmation.class.ts
+++ b/src/core/helpers/genlite-confirmation.class.ts
@@ -39,14 +39,14 @@ export class GenLiteConfirmation {
 
         let header = document.createElement('div');
         header.id = 'genlite-confirm-header';
-        header.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/generic_modal_top.png")';
+        header.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.120/data_client/img/new_ux/login_screen_images/generic_modal_top.png")';
         header.style.backgroundSize = '100%, 100%';
         header.style.width = '100%';
         header.style.aspectRatio = '2106/310'; // background png size
         modal.appendChild(header);
 
         let title = document.createElement('div');
-        title.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/modal_title.png")';
+        title.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.120/data_client/img/new_ux/login_screen_images/modal_title.png")';
         title.style.position = 'fixed';
         title.style.width = '40%';
         title.style.aspectRatio = '632/120';
@@ -71,7 +71,7 @@ export class GenLiteConfirmation {
 
         let body = document.createElement('div');
         body.id = 'genlite-confirm-body';
-        body.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/generic_modal_mid_and_bottom.png")';
+        body.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.120/data_client/img/new_ux/login_screen_images/generic_modal_mid_and_bottom.png")';
         body.style.backgroundSize = '100%, 100%';
         body.style.width = '100%';
         body.style.aspectRatio = '2104/1316'; // background png size
@@ -114,7 +114,7 @@ export class GenLiteConfirmation {
 
         // okay button actually cancels genlite
         let okayButton = document.createElement('div');
-        okayButton.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/return_button.png")';
+        okayButton.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.120/data_client/img/new_ux/login_screen_images/return_button.png")';
         okayButton.style.backgroundSize = '100%, 100%';
         okayButton.style.width = '15%';
         okayButton.style.aspectRatio = '131/52'; // background png size
@@ -136,7 +136,7 @@ export class GenLiteConfirmation {
 
         // cancel button is actually the accept button
         let cancelButton = document.createElement('div');
-        cancelButton.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/crafting/crafting_2/make_all.png")';
+        cancelButton.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.120/data_client/img/new_ux/crafting/crafting_2/make_all.png")';
         cancelButton.style.backgroundSize = '100%, 100%';
         cancelButton.style.width = '15%';
         cancelButton.style.aspectRatio = '188/72'; // background png size

--- a/src/core/helpers/genlite-confirmation.class.ts
+++ b/src/core/helpers/genlite-confirmation.class.ts
@@ -15,4 +15,147 @@ export class GenLiteConfirmation {
     static async confirm(message: string) {
         return window.confirm(message);
     }
+
+    static async confirmModal(message: string[], callback: () => void) {
+        let bg = document.createElement('div');
+        bg.style.height = '100%';
+        bg.style.width = '100%';
+        bg.style.position = 'absolute';
+        bg.style.left = '0';
+        bg.style.top = '0';
+        bg.style.backgroundColor = 'rgba(255, 255, 255, 0.5)';
+        bg.style.zIndex = '1000';
+        bg.style.backdropFilter = 'blur(5px)';
+        document.body.appendChild(bg);
+
+        let modal = document.createElement('div');
+        modal.id = 'genlite-confirm-modal';
+        modal.style.position = 'fixed';
+        modal.style.top = '50%';
+        modal.style.left = '50%';
+        modal.style.width = '40%';
+        modal.style.transform = 'translate(-50%, -50%)';
+        bg.appendChild(modal);
+
+        let header = document.createElement('div');
+        header.id = 'genlite-confirm-header';
+        header.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/generic_modal_top.png")';
+        header.style.backgroundSize = '100%, 100%';
+        header.style.width = '100%';
+        header.style.aspectRatio = '2106/310'; // background png size
+        modal.appendChild(header);
+
+        let title = document.createElement('div');
+        title.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/modal_title.png")';
+        title.style.position = 'fixed';
+        title.style.width = '40%';
+        title.style.aspectRatio = '632/120';
+        title.style.backgroundSize = '100%, 100%';
+        title.style.top = '0';
+        title.style.left = '50%';
+        title.style.transform = 'translate(-50%, -25%)';
+        title.style.textAlign = 'center';
+        title.style.textShadow = '-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000';
+        title.style.fontFamily = 'acme,times new roman,Times,serif';
+        title.style.fontSize = '1.5rem';
+        title.style.color = 'white';
+        title.style.overflow = 'hidden';
+
+        title.style.display = 'flex';
+        title.style.justifyContent = 'center';
+        title.style.alignContent = 'center';
+        title.style.flexDirection = 'column';
+
+        title.innerText = 'GenLite Warning';
+        header.appendChild(title);
+
+        let body = document.createElement('div');
+        body.id = 'genlite-confirm-body';
+        body.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/generic_modal_mid_and_bottom.png")';
+        body.style.backgroundSize = '100%, 100%';
+        body.style.width = '100%';
+        body.style.aspectRatio = '2104/1316'; // background png size
+
+        body.style.textAlign = 'center';
+        body.style.textShadow = '-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000';
+        body.style.fontFamily = 'acme,times new roman,Times,serif';
+        body.style.fontSize = '1.5rem';
+        body.style.color = 'white';
+        modal.appendChild(body);
+
+        let scrollBox = document.createElement('div');
+        scrollBox.style.width = '100%';
+        scrollBox.style.height = '75%';
+        scrollBox.style.overflowY = 'scroll';
+        body.appendChild(scrollBox);
+
+        let list = document.createElement('ul');
+        list.style.marginTop = '0';
+        list.style.paddingTop = '0';
+        list.style.paddingLeft = '4em';
+        list.style.paddingRight = '3em';
+        list.style.paddingBottom = '1em';
+        list.style.textAlign = 'left';
+        for (const item of message) {
+            let li = document.createElement('li');
+            li.innerText = item;
+            list.appendChild(li);
+        }
+        scrollBox.appendChild(list);
+
+        let confirmText = document.createElement('span');
+        confirmText.style.display = 'inline-block';
+        confirmText.style.width = '75%';
+        confirmText.style.textAlign = 'center';
+        confirmText.style.paddingBottom = '2em';
+        confirmText.innerText = 'Press Cancel to continue, Press Okay to disable GenLite';
+        scrollBox.appendChild(confirmText);
+
+        // okay button actually cancels genlite
+        let okayButton = document.createElement('div');
+        okayButton.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/login_screen_images/return_button.png")';
+        okayButton.style.backgroundSize = '100%, 100%';
+        okayButton.style.width = '15%';
+        okayButton.style.aspectRatio = '131/52'; // background png size
+        okayButton.style.position = 'fixed';
+        okayButton.style.top = '100%';
+        okayButton.style.left = '40%';
+        okayButton.style.transform = 'translate(-50%, -175%)';
+
+        okayButton.style.display = 'flex';
+        okayButton.style.justifyContent = 'center';
+        okayButton.style.alignContent = 'center';
+        okayButton.style.flexDirection = 'column';
+        okayButton.style.cursor = 'pointer';
+        okayButton.innerText = 'Okay';
+        okayButton.onclick = (e) => {
+            bg.remove();
+        };
+        scrollBox.appendChild(okayButton);
+
+        // cancel button is actually the accept button
+        let cancelButton = document.createElement('div');
+        cancelButton.style.backgroundImage = 'url("https://genfanad-static.s3.us-east-2.amazonaws.com/versioned/0.118/data_client/img/new_ux/crafting/crafting_2/make_all.png")';
+        cancelButton.style.backgroundSize = '100%, 100%';
+        cancelButton.style.width = '15%';
+        cancelButton.style.aspectRatio = '188/72'; // background png size
+        cancelButton.style.position = 'fixed';
+        cancelButton.style.top = '100%';
+        cancelButton.style.left = '60%';
+        cancelButton.style.transform = 'translate(-50%, -175%)';
+
+        cancelButton.style.display = 'flex';
+        cancelButton.style.justifyContent = 'center';
+        cancelButton.style.alignContent = 'center';
+        cancelButton.style.flexDirection = 'column';
+        cancelButton.style.cursor = 'pointer';
+        cancelButton.innerText = 'Cancel';
+        cancelButton.onclick = (e) => {
+            bg.remove();
+            callback();
+        };
+        scrollBox.appendChild(cancelButton);
+
+        return false;
+    }
 }

--- a/src/core/interfaces/chat.interface.ts
+++ b/src/core/interfaces/chat.interface.ts
@@ -1,3 +1,16 @@
+/*
+    Copyright (C) 2023 snwhd
+*/
+/*
+    This file is part of GenLite.
+
+    GenLite is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+    GenLite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along with Foobar. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 interface Message {
     message: HTMLElement;
     timestamp: string;

--- a/src/core/interfaces/chat.interface.ts
+++ b/src/core/interfaces/chat.interface.ts
@@ -1,0 +1,69 @@
+interface Message {
+    message: HTMLElement;
+    timestamp: string;
+}
+    
+interface MessageBuffer {
+    messages: Message[];
+
+    add(message: HTMLElement, timestamp: string): void;
+    nth(offset: number): Message;
+    clear(): void;
+}
+
+interface IFilterButton {
+    button: HTMLElement;
+    buffer: MessageBuffer;
+    class?: string;
+    visible?: boolean;
+}
+
+interface Chat {
+    DOM_input: HTMLElement;
+    DOM_input_cover: HTMLElement;
+    DOM_chat_buffer: HTMLElement;
+
+    filter_buttons: Record<string, IFilterButton>;
+    system_buffer: MessageBuffer;
+    focusOutHandler: Function;
+    focus_locked: boolean;
+    scroll_locked: boolean;
+    show_timestamps: boolean;
+    chat_buffer: HTMLElement[];
+
+    processInput(): void;
+
+    addGameMessage(text: string): void;
+    addPrivateMessage(
+        timestamp: number,
+        speaker: string,
+        text: string,
+        icon: boolean,
+        loopback: boolean,
+        name: string
+    ): void;
+    addPublicMessage(
+        timestamp: number,
+        speaker: string,
+        text: string,
+        icon: boolean
+    ): void;
+    addQuestMessage(
+        timestamp: number,
+        speaker: string,
+        icon: boolean
+    ): void;
+    addSystemBroadcastMessage(
+        timestamp: number,
+        text: string
+    ): void;
+    addMessage(
+        type: string,
+        timestamp: number,
+        speaker: string,
+        text: string,
+        icon: boolean
+    ): void;
+
+    prototype: any;
+}

--- a/src/core/interfaces/item.interface.ts
+++ b/src/core/interfaces/item.interface.ts
@@ -1,56 +1,58 @@
-interface Location {
-  position: {
-    x: number;
-    y: number;
-  }
+interface ILocation {
+    position: {
+        x: number;
+        y: number;
+    }
 }
 
-interface ItemInfo {
-  ids: { [id: string]: boolean };
-  value: number;
-  name: string;
-  text(): string;
-  examine: string;
+interface IItemInfo {
+    ids: { [id: string]: boolean };
+    value: number;
+    name: string;
+    text(): string;
+    examine: string;
 }
 
-interface Sprite {
-  sprite: any; // THREE.Sprite;
-  ids: { [id: string]: boolean };
+interface ISprite {
+    sprite: any; // THREE.Sprite;
+    ids: { [id: string]: boolean };
 }
 
-interface ItemKeys {
-  [id: string]: {
-    image: string;
-    item_id: string;
-  }
+interface IItemKeys {
+    [id: string]: {
+        image: string;
+        item_id: string;
+    }
 }
 
-interface Action {
-  color: string;
-  distance: number;
-  priority: number;
-  object: ItemInfo;
-  text: string;
-  action: () => void;
+interface IAction {
+    color: string;
+    distance: number;
+    priority: number;
+    object: IItemInfo;
+    text: string;
+    action: () => void;
 }
 
-interface ItemStack {
-  id: string;
-  location: Location;
-  dirty: boolean;
-  item_keys: ItemKeys;
-  sprites: { [image: string]: Sprite };
-  item_info: { [item_id: string]: ItemInfo };
-  optimizationX: number;
-  optimizationY: number;
-  ignore_intersections: boolean;
-  mesh: any; // THREE.Group;
-  worldPos: { x: number; y: number; z: number };
-  position(): { x: number; y: number; z: number };
-  text(): string;
-  actions(): Action[];
-  addInstance(id: string, def: { item: string }): void;
-  removeInstance(id: string): boolean;
-  intersects(ray: any /*THREE.Raycaster*/, list: Action[]): void;
-  update(cam: any /*THREE.Camera*/, dt: number): void;
+interface IItemStack {
+    id: string;
+    location: ILocation;
+    dirty: boolean;
+    item_keys: IItemKeys;
+    sprites: { [image: string]: ISprite };
+    item_info: { [item_id: string]: IItemInfo };
+    optimizationX: number;
+    optimizationY: number;
+    ignore_intersections: boolean;
+    mesh: any; // THREE.Group;
+    worldPos: { x: number; y: number; z: number };
+    position(): { x: number; y: number; z: number };
+    text(): string;
+    actions(): IAction[];
+    addInstance(id: string, def: { item: string }): void;
+    removeInstance(id: string): boolean;
+    intersects(ray: any /*THREE.Raycaster*/, list: IAction[]): void;
+    update(cam: any /*THREE.Camera*/, dt: number): void;
+
+    prototype: any;
 }

--- a/src/core/interfaces/item.interface.ts
+++ b/src/core/interfaces/item.interface.ts
@@ -1,0 +1,56 @@
+interface Location {
+  position: {
+    x: number;
+    y: number;
+  }
+}
+
+interface ItemInfo {
+  ids: { [id: string]: boolean };
+  value: number;
+  name: string;
+  text(): string;
+  examine: string;
+}
+
+interface Sprite {
+  sprite: any; // THREE.Sprite;
+  ids: { [id: string]: boolean };
+}
+
+interface ItemKeys {
+  [id: string]: {
+    image: string;
+    item_id: string;
+  }
+}
+
+interface Action {
+  color: string;
+  distance: number;
+  priority: number;
+  object: ItemInfo;
+  text: string;
+  action: () => void;
+}
+
+interface ItemStack {
+  id: string;
+  location: Location;
+  dirty: boolean;
+  item_keys: ItemKeys;
+  sprites: { [image: string]: Sprite };
+  item_info: { [item_id: string]: ItemInfo };
+  optimizationX: number;
+  optimizationY: number;
+  ignore_intersections: boolean;
+  mesh: any; // THREE.Group;
+  worldPos: { x: number; y: number; z: number };
+  position(): { x: number; y: number; z: number };
+  text(): string;
+  actions(): Action[];
+  addInstance(id: string, def: { item: string }): void;
+  removeInstance(id: string): boolean;
+  intersects(ray: any /*THREE.Raycaster*/, list: Action[]): void;
+  update(cam: any /*THREE.Camera*/, dt: number): void;
+}

--- a/src/core/interfaces/item.interface.ts
+++ b/src/core/interfaces/item.interface.ts
@@ -1,3 +1,16 @@
+/*
+    Copyright (C) 2023 snwhd
+*/
+/*
+    This file is part of GenLite.
+
+    GenLite is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+    GenLite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along with Foobar. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 interface ILocation {
     position: {
         x: number;

--- a/src/core/plugins/genlite-commands.plugin.ts
+++ b/src/core/plugins/genlite-commands.plugin.ts
@@ -9,6 +9,7 @@ export class GenLiteCommandsPlugin {
         document.genlite.registerPlugin(this);
 
         this.originalProcessInput = document.game.Chat.prototype.processInput;
+
         this.register("help", function (s) {
             if (!s) {
                 let helpStr = Object.keys(document.genlite.commands.commands).join(", ");

--- a/src/core/plugins/genlite-database.plugin.ts
+++ b/src/core/plugins/genlite-database.plugin.ts
@@ -1,3 +1,16 @@
+/*
+    Copyright (C) 2023 snwhd
+*/
+/*
+    This file is part of GenLite.
+
+    GenLite is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+    GenLite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along with Foobar. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 type DatabaseCallback = (db: IDBDatabase) => void;
 type StoreCallback = (db: IDBObjectStore) => void;
 

--- a/src/core/plugins/genlite-database.plugin.ts
+++ b/src/core/plugins/genlite-database.plugin.ts
@@ -1,0 +1,88 @@
+type DatabaseCallback = (db: IDBDatabase) => void;
+type StoreCallback = (db: IDBObjectStore) => void;
+
+export class GenLiteDatabasePlugin {
+    public static pluginName = 'GenLiteDatabasePlugin';
+    public static dbName = 'GenLiteDatabase';
+    public static version = 2;
+
+    public supported = false;
+
+    stores: Array<{callback: DatabaseCallback}> = [];
+
+    async init() {
+        window.genlite.registerPlugin(this);
+    }
+
+    public add(callback: DatabaseCallback) {
+        this.stores.push({
+            callback: callback
+        });
+    }
+
+    public open(callback: DatabaseCallback) {
+        if (!this.supported) {
+            return;
+        }
+
+        let r = this.request();
+        if (r) {
+            r.onsuccess = (e) => {
+                callback(r.result);
+            }
+        }
+    }
+
+    public storeTx(
+        store: string,
+        rw: 'readwrite'|'readonly',
+        callback: StoreCallback
+    ) {
+        if (!this.supported) {
+            return;
+        }
+
+        let r = this.request();
+        if (r) {
+            r.onsuccess = (e) => {
+                let db = r.result;
+                let tx = db.transaction(store, rw);
+                callback(tx.objectStore(store));
+            }
+        }
+    }
+
+    request() {
+        if (!this.supported) {
+            return null;
+        }
+
+        let r = window.indexedDB.open(
+            GenLiteDatabasePlugin.dbName,
+            GenLiteDatabasePlugin.version
+        );
+        r.onerror = (e) => {
+            console.log('GenLiteDatabaseError: ' + e);
+        };
+
+        return r;
+    }
+
+    async postInit() {
+        this.supported = 'indexedDB' in window;
+        let r = this.request();
+        if (r) {
+            r.onsuccess = (e) => {
+                // TODO: plugin onopen actions
+                r.result.close();
+            };
+            r.onupgradeneeded = (e: any) => {
+                let db = e.target.result;
+                for (const store of this.stores) {
+                    store.callback(db);
+                }
+            };
+        }
+    }
+
+}

--- a/src/core/plugins/genlite-database.plugin.ts
+++ b/src/core/plugins/genlite-database.plugin.ts
@@ -11,7 +11,7 @@ export class GenLiteDatabasePlugin {
     stores: Array<{callback: DatabaseCallback}> = [];
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
     }
 
     public add(callback: DatabaseCallback) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { GenLiteNotificationPlugin } from "./core/plugins/genlite-notification.p
 import { GenLiteSettingsPlugin } from "./core/plugins/genlite-settings.plugin";
 import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
 import { GenLiteConfirmation } from "./core/helpers/genlite-confirmation.class";
-
+import { GenLiteDatabasePlugin } from "./core/plugins/genlite-database.plugin";
 
 /** Official Plugins */
 import { GenLiteVersionPlugin } from "./plugins/genlite-version.plugin";
@@ -191,6 +191,7 @@ let isInitialized = false;
         genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
         genlite.settings = await genlite.pluginLoader.addPlugin(GenLiteSettingsPlugin);
         genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
+        genlite.database = await genlite.pluginLoader.addPlugin(GenLiteDatabasePlugin);
 
         /** Official Plugins */
         await genlite.pluginLoader.addPlugin(GenLiteVersionPlugin);
@@ -217,6 +218,7 @@ let isInitialized = false;
         await genlite.pluginLoader.addPlugin(GenLiteHealthRegenerationPlugin);
 
         /** post init things */
+        await document['GenLiteDatabasePlugin'].postInit();
         await document['GenLiteSettingsPlugin'].postInit();
         await document['GenLiteNPCHighlightPlugin'].postInit();
         await document['GenLiteDropRecorderPlugin'].postInit();

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,14 +57,14 @@ declare global {
     }
 }
 
-const DISCLAIMER = `
-GenLite is NOT associated with Rose-Tinted Games.
-Do not talk about GenLite in the main discord.
-Do not report bugs to the devs with GenLite enabled, they will ignore you and get annoyed.
-Do disable GenLite first and test for the bug again.
-If you find a bug and are unsure post in the GenLite Server. We will help you.
-While we work to ensure compatibility, Use At Your Own Risk.
-Press Cancel to Load, Press Okay to Stop.`;
+const DISCLAIMER = [
+    "GenLite is NOT associated with Rose-Tinted Games.",
+    "DO NOT talk about GenLite in the Genfanad Discord.",
+    "DO NOT report bugs to Genfanad with GenLite enabled. They will ignore you and get annoyed.",
+    "DO disable GenLite first and test for the bug again.",
+    "If you find a bug and are unsure, post in the GenLite Discord. We will help you.",
+    "While we work to ensure compatibility, Use At Your Own Risk.",
+];
 
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
@@ -87,12 +87,6 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
 let isInitialized = false;
 
 (async function load() {
-    let confirmed = localStorage.getItem("GenLiteConfirms");
-    if (!confirmed && await GenLiteConfirmation.confirm(DISCLAIMER) === true)
-        return;
-    confirmed = "true";
-    localStorage.setItem("GenLiteConfirms", confirmed);
-
     async function initGenLite() {
 
         function gameObject(
@@ -271,11 +265,22 @@ let isInitialized = false;
     window.addEventListener('load', (e) => {
         document.initGenLite = initGenLite;
 
+        let confirmed = localStorage.getItem("GenLiteConfirms");
+        if (!confirmed) {
+            await GenLiteConfirmation.confirmModal(DISCLAIMER, async () => {
+                // calls back only if accepted
+                localStorage.setItem("GenLiteConfirms", "true");
+                confirmed = true;
+            });
+        }
+
         let doc = (document as any)
         doc.client.set('document.client.originalStartScene', doc.client.get('qS'));
         doc.client.set('qS', function () {
             document.client.originalStartScene();
-            setTimeout(document.initGenLite, 100);
+            if (confirmed) {
+                setTimeout(document.initGenLite, 100);
+            }
         });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,27 +261,32 @@ let isInitialized = false;
         }
     }
 
+    function hookStartScene() {
+        if (localStorage.getItem("GenLiteConfirms") === "true") {
+            let doc = (document as any);
+            doc.client.set('document.client.originalStartScene', doc.client.get('qS'));
+            doc.client.set('qS', function () {
+                document.client.originalStartScene();
+                setTimeout(document.initGenLite, 100);
+            });
+        }
+    }
+
     hookClient();
     window.addEventListener('load', (e) => {
         document.initGenLite = initGenLite;
 
         let confirmed = localStorage.getItem("GenLiteConfirms");
-        if (!confirmed) {
-            await GenLiteConfirmation.confirmModal(DISCLAIMER, async () => {
+        if (confirmed === "true") {
+            hookStartScene();
+        } else {
+            GenLiteConfirmation.confirmModal(DISCLAIMER, async () => {
                 // calls back only if accepted
                 localStorage.setItem("GenLiteConfirms", "true");
-                confirmed = true;
+                hookStartScene();
             });
         }
 
-        let doc = (document as any)
-        doc.client.set('document.client.originalStartScene', doc.client.get('qS'));
-        doc.client.set('qS', function () {
-            document.client.originalStartScene();
-            if (confirmed) {
-                setTimeout(document.initGenLite, 100);
-            }
-        });
     });
 
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import { GenLiteSoundNotification } from "./plugins/genlite-sound-notification.p
 import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand.plugin";
 import { GenLitePlayerToolsPlugin } from "./plugins/genlite-playertools.plugin";
 import { GenLiteHighscores } from "./plugins/genlite-highscores.plugin";
-import {GenLiteItemDisplays} from "./plugins/genlite-itemdisplay.plugin";
+import { GenLiteItemDisplays } from "./plugins/genlite-itemdisplay.plugin";
 import { GenLiteHealthRegenerationPlugin } from './plugins/genlite-health-regeneration.plugin';
 
 declare const GM_getResourceText: (s: string) => string;

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -13,6 +13,151 @@
 
 import { GenLitePlugin } from '../core/interfaces/plugin.interface';
 
+/*
+ * Chat plugin order of operations
+ *  - message is received
+ *  - if channel is 'game' and filter game chat enabled and text matches filter
+ *       then message is discarded entirely.
+ *  - if preserve chat log is enabled
+ *       then message is saved to indexedDB
+ *  - if condense is enabled and text matches previous message
+ *       then new message is updated with a count
+ *       and the previous one is discarded
+ *  - if not discarded above, add to chat
+ *
+ */
+
+class GenLiteMessageBuffer {
+
+    channel: string;
+    buffer: MessageBuffer;
+    originalAdd: (message: HTMLElement, timestamp: string) => void;
+
+    constructor(name: string, buffer: MessageBuffer) {
+        this.channel = name;
+        this.buffer = buffer;
+        this.originalAdd = buffer.add;
+    }
+
+    public hook() {
+        let plugin = this;
+        this.buffer.add = this.overrideAdd.bind(this.buffer, this);
+    }
+
+    public unhook() {
+        this.buffer.add = this.originalAdd;
+    }
+
+    overrideAdd(
+        glbuffer: GenLiteMessageBuffer,
+        message: HTMLElement,
+        timestamp: string
+    ) {
+        // roundabout casting to MessageBuffer because this is used to
+        // override MessageBuffer.add
+        let self = ((this as any) as MessageBuffer);
+        let plugin = document[GenLiteChatPlugin.pluginName];
+
+        // This class overrides MessageBuffer which operates on HTML
+        // elements, so we need to parse the specific fields ouf of the
+        // element. We could override methods on Chat instead to avoid
+        // this, but then we'd conflict with other chat features and
+        // require a separate override per chat channel.
+
+        // the current element structure is:
+        // <div: message>
+        //  <span: timestamp>
+        //  ?<span: imgwrapper><img: icon>
+        //  ?<span: speaker>
+        //  <span: text>
+
+        let speaker: string = null;
+        let elements = message.getElementsByClassName('new_ux-message-user');
+        if (elements.length === 1) {
+            let e = elements[0] as HTMLElement;
+            speaker = e.innerText;
+        }
+
+        let content = message.getElementsByClassName(
+            'new_ux-message-text'
+        )[0].innerHTML;
+
+        if (plugin.preserveMessages) {
+            glbuffer.storeMessage(speaker, content, timestamp);
+        }
+
+        if (plugin.condenseMessages) {
+            // TODO: optimize a bit
+            for (const existing of self.messages) {
+                let es = existing.message.getElementsByClassName('new_ux-message-text');
+                let existingContent = es[0].innerHTML;
+
+                es = existing.message.getElementsByClassName('new_ux-message-user');
+                let existingSpeaker = es.length > 0 ? (es[0] as HTMLElement).innerText : null;
+
+                if (existingContent === content && existingSpeaker === speaker) {
+                    let countElements = existing.message.getElementsByClassName('genlite-message-counter');
+                    let count: HTMLElement = null;
+                    if (countElements.length > 0) {
+                        count = countElements[0] as HTMLElement;
+                    } else {
+                        count = document.createElement('span')
+                        count.classList.add('genlite-message-counter');
+                        count.style.float = 'right';
+                        count.innerText = '(1)';
+                        existing.message.appendChild(count);
+                    }
+
+                    let text = count.innerText;
+                    let number = parseInt(text.substr(1, text.length - 2)) + 1; // trim parens
+                    count.innerText = '(' + number + ')';
+
+                    // move count to the new element
+                    count.remove();
+                    message.appendChild(count);
+
+                    // remove from MessageBuffer
+                    self.messages.splice(self.messages.indexOf(existing), 1);
+
+                    // remove the old message element
+                    existing.message.remove();
+
+                    // and remove it from CHAT's internal buffer
+                    let index = CHAT.chat_buffer.indexOf(message);
+                    if (index >= 0) {
+                        CHAT.chat_buffer.splice(index, 1);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        glbuffer.originalAdd.bind(self)(message, timestamp);
+    };
+
+    storeMessage(
+        speaker: string,
+        text: string,
+        timestamp: string,
+    ) {
+        let plugin = document[GenLiteChatPlugin.pluginName];
+        let db = plugin.chatDB;
+        if (db) {
+            const tx = db.transaction('chatlog', 'readwrite');
+            const store = tx.objectStore('chatlog');
+
+            store.put({
+                channel: this.channel,
+                timestamp: timestamp,
+                speaker: speaker,
+                text: text,
+            });
+        }
+    }
+
+}
+
 export class GenLiteChatPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteChatPlugin';
     static storageKey = 'IgnoredGameChatMessages';
@@ -20,19 +165,60 @@ export class GenLiteChatPlugin implements GenLitePlugin {
     customMessagesToIgnore: Set<string> = new Set<string>();
 
     filterGameMessages: boolean = false;
-    originalGameMessage: Function;
+    preserveMessages: boolean = false;
+    condenseMessages: boolean = false;
+    originalGameMessage: (text: string) => void;
+
+    indexedDBSupported = false;
+    bufferHooked: boolean = false;
+    buffers: Record<string, GenLiteMessageBuffer> = {};
+
+    chatDB: IDBDatabase;
 
     async init() {
         document.genlite.registerPlugin(this);
-        this.filterGameMessages = document.genlite.settings.add(
-            "Chat.FilterGameMessages",
+        this.condenseMessages = document.genlite.settings.add(
+            'Chat.CondenseMessages',
             false,
-            "Filter Game Chat",
-            "checkbox",
+            'Condense Chat Messages',
+            'checkbox',
+            this.handleCondenseMessages,
+            this
+        );
+
+        this.indexedDBSupported = 'indexedDB' in window;
+        if (this.indexedDBSupported) {
+            this.preserveMessages = document.genlite.settings.add(
+                'Chat.PreserveMessages',
+                false,
+                'Preserve Chat Log',
+                'checkbox',
+                this.handlePreserveMessages,
+                this
+            );
+        } else {
+            this.preserveMessages = false;
+            console.log(
+                '%c IndexedDB is not supported, cannot save chat logs',
+                'color:red'
+            );
+        }
+
+        this.filterGameMessages = document.genlite.settings.add(
+            'Chat.FilterGameMessages',
+            false,
+            'Filter Game Chat',
+            'checkbox',
             this.handleFilterGameMessages,
             this
         );
         this.customMessagesToIgnore = this.loadSavedSettings();
+
+        document.genlite.commands.register(
+            'log',
+            this.handleCommand.bind(this),
+            this.helpCommand.bind(this)
+        );
     }
 
     public loginOK() {
@@ -45,7 +231,31 @@ export class GenLiteChatPlugin implements GenLitePlugin {
         this.updateState();
     }
 
+    handleCondenseMessages(state: boolean) {
+        this.condenseMessages = state;
+        this.updateState();
+    }
+
+    handlePreserveMessages(state: boolean) {
+        this.preserveMessages = state;
+        this.updateState();
+    }
+
     updateState() {
+        if (this.condenseMessages || this.preserveMessages) {
+            if (!this.chatDB) {
+                this.initDB();
+            }
+            this.hookBuffer();
+        } else {
+            if (this.chatDB) {
+                console.log('ChatDabase: closed');
+                this.chatDB.close();
+                this.chatDB = null;
+            }
+            this.unhookBuffer();
+        }
+
         if (this.filterGameMessages) {
             document.game.CHAT.addGameMessage = this.newGameMessage.bind(
                 document.game.CHAT,
@@ -54,6 +264,27 @@ export class GenLiteChatPlugin implements GenLitePlugin {
             );
         } else {
             document.game.CHAT.addGameMessage = this.originalGameMessage;
+        }
+    }
+
+    hookBuffer() {
+        if (!this.bufferHooked) {
+            for (const channel in CHAT.filter_buttons) {
+                let buffer = CHAT.filter_buttons[channel].buffer;
+                let glbuffer = new GenLiteMessageBuffer(channel, buffer);
+                this.buffers[channel] = glbuffer;
+                glbuffer.hook();
+            }
+            this.bufferHooked = true;
+        }
+    }
+
+    unhookBuffer() {
+        if (this.bufferHooked) {
+            for (const channel in this.buffers) {
+                this.buffers[channel].unhook();
+            }
+            this.bufferHooked = false;
         }
     }
 
@@ -69,9 +300,24 @@ export class GenLiteChatPlugin implements GenLitePlugin {
                         object: null,
                         text: 'Ignore This Message',
                         action: () => {
-                            plugin.ignoreGameMessage(dom.lastChild.innerHTML);
+                            let content = dom.getElementsByClassName(
+                                'new_ux-message-text'
+                            )[0].innerHTML;
+                            plugin.ignoreGameMessage(content);
                         },
                     });
+                    // list.push({
+                    //     color: 'red',
+                    //     blockLeftClick: true,
+                    //     priority: 1,
+                    //     object: null,
+                    //     text: 'Delete This Message',
+                    //     action: () => {
+                    //         // Note: this only hides the element, it is not
+                    //         // removed from the internal chat buffer or indexeddb
+                    //         dom.remove();
+                    //     },
+                    // });
                 };
             }
         }
@@ -98,11 +344,77 @@ export class GenLiteChatPlugin implements GenLitePlugin {
 
     saveSettings() {
         let s = this.customMessagesToIgnore;
-        console.log('saving', s);
         localStorage.setItem(
             GenLiteChatPlugin.storageKey,
             JSON.stringify(Array.from(s))
         );
+    }
+
+    initDB() {
+        let r = window.indexedDB.open('GenLiteChatDatabase', 2);
+        r.onerror = (e) => {
+            console.log('ChatDabaseError: ' + e);
+        };
+        r.onsuccess = (e) => {
+            console.log('ChatDatabase: opened');
+            this.chatDB = r.result;
+        };
+        r.onupgradeneeded = (e: any) => {
+            let db = e.target.result;
+            let store = db.createObjectStore('chatlog', {
+                keyPath: 'key',
+                autoIncrement: true
+            });
+            store.createIndex('indexKey', 'key', {unique: true});
+        };
+    }
+
+    handleCommand(args: string) {
+        let end = args.indexOf(' ');
+        if (end == -1) {
+            end = args.length;
+        }
+        let subcommand = args.slice(0, end);
+        let arg = args.slice(end + 1);
+
+        if (!this.chatDB) {
+            document.genlite.commands.print('Chat DB not available.');
+            document.genlite.commands.print('Enable "preserve chat log" in settings.');
+            return;
+        }
+
+        switch (subcommand) {
+            case 'size':
+                let tx = this.chatDB.transaction('chatlog', 'readonly');
+                let store = tx.objectStore('chatlog');
+                let cursor = store.openCursor(null, 'prev');
+                cursor.onsuccess = (e: any) => {
+                    let maxKey = e.target.result.value.key;
+                    document.genlite.commands.print('Chat messages saved: ' + maxKey);
+                };
+                break;
+            default:
+                this.helpCommand('');
+                break
+        }
+    }
+
+    helpCommand(args: string) {
+        let end = args.indexOf(' ');
+        if (end == -1) {
+            end = args.length;
+        }
+        let subcommand = args.slice(0, end);
+        let arg = args.slice(end + 1);
+
+        switch (subcommand) {
+            case 'size':
+                document.genlite.commands.print('size of saved chat log');
+                break;
+            default:
+                document.genlite.commands.print('subcommands: size');
+                break;
+        }
     }
 
 }

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -17,16 +17,6 @@ export class GenLiteChatPlugin implements GenLitePlugin {
     static pluginName = 'GenLiteChatPlugin';
     static storageKey = 'IgnoredGameChatMessages';
 
-    static gameMessagesToIgnore: Set<string> = new Set<string>([
-        "You start mining the rock.",
-        "You fail to get some ore.",
-        "You get some ore.",
-        "You stop mining the rock.",
-        "The rock is out of ore.",
-        "Your inventory is full",
-        "Might have some useful ore inside.",
-    ]);
-
     customMessagesToIgnore: Set<string> = new Set<string>();
 
     filterGameMessages: boolean = false;
@@ -68,11 +58,7 @@ export class GenLiteChatPlugin implements GenLitePlugin {
     }
 
     newGameMessage(plugin, original, text) {
-        let ignore = (
-            GenLiteChatPlugin.gameMessagesToIgnore.has(text) ||
-            plugin.customMessagesToIgnore.has(text)
-        );
-        if (!ignore) {
+        if (!plugin.customMessagesToIgnore.has(text)) {
             let dom = original.bind(this)(text);
             if (dom && !dom.add_interactions) {
                 dom.add_interactions = (list) => {

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -123,7 +123,7 @@ class GenLiteMessageBuffer {
                     existing.message.remove();
 
                     // and remove it from CHAT's internal buffer
-                    let index = CHAT.chat_buffer.indexOf(message);
+                    let index = CHAT.chat_buffer.indexOf(existing.message);
                     if (index >= 0) {
                         CHAT.chat_buffer.splice(index, 1);
                     }

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -123,9 +123,9 @@ class GenLiteMessageBuffer {
                     existing.message.remove();
 
                     // and remove it from CHAT's internal buffer
-                    let index = CHAT.chat_buffer.indexOf(existing.message);
+                    let index = document.game.CHAT.chat_buffer.indexOf(existing.message);
                     if (index >= 0) {
-                        CHAT.chat_buffer.splice(index, 1);
+                        document.game.CHAT.chat_buffer.splice(index, 1);
                     }
 
                     break;
@@ -264,8 +264,8 @@ export class GenLiteChatPlugin implements GenLitePlugin {
 
     hookBuffer() {
         if (!this.bufferHooked) {
-            for (const channel in CHAT.filter_buttons) {
-                let buffer = CHAT.filter_buttons[channel].buffer;
+            for (const channel in document.game.CHAT.filter_buttons) {
+                let buffer = document.game.CHAT.filter_buttons[channel].buffer;
                 let glbuffer = new GenLiteMessageBuffer(channel, buffer);
                 this.buffers[channel] = glbuffer;
                 glbuffer.hook();

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -217,7 +217,6 @@ export class GenLiteChatPlugin implements GenLitePlugin {
             this
         );
         this.customMessagesToIgnore = this.loadSavedSettings();
-
         document.genlite.commands.register(
             'log',
             this.handleCommand.bind(this),


### PR DESCRIPTION
### interfaces
- Chat
- Item, ItemStack

### database plugin
- allows plugins to create object stores in the same central indexeddb
- wrappers for common task (open db, store tx)
Note: if a new object store is added, the database version needs to be bumped.

### chat plugin
- "filter game chat" enables the right-click "ignore this message" option for game chat, hiding all future instances of that message.
- "preserve chat log" stores all chat messages in indexeddb
- "condense chat messages" de-duplicates chat messages and adds a counter on the right of chat

### genlite warning
- instead of window.confirm, use custom modal with genfanad style
- refactor index.ts a little to support this