### PR TITLE
window.genlite.socket hook based expose plugin

### DIFF
--- a/src/core/plugins/genlite-websocket.plugin.ts
+++ b/src/core/plugins/genlite-websocket.plugin.ts
@@ -1,0 +1,24 @@
+import { GenLitePlugin } from '../interfaces/plugin.interface';
+
+/**
+ * Exposes the most recently created WebSocket instance to window.genlite.socket
+ * the socket typically uses socket.io and can be used for listening to messages in any plugin, e.g:
+ * @example
+ * window.genlite.on("stats", (data) => { console.log(data); });
+ */
+export class GenLiteWebSocketPlugin implements GenLitePlugin {
+    static pluginName = 'GenLiteWebSocketPlugin';
+
+    public socket: WebSocket;
+
+    async init() {
+      const originalWebSocket: any = WebSocket;
+
+      (window.WebSocket as any) = function (...args) {
+        console.log(`[${GenLiteWebSocketPlugin.pluginName}] WebSocket hook successful.`);
+        window.genlite.socket = new originalWebSocket(...args);
+
+        return window.genlite.socket;
+      }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { GenLiteNotificationPlugin } from "./core/plugins/genlite-notification.p
 import { GenLiteSettingsPlugin } from "./core/plugins/genlite-settings.plugin";
 import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
 import { GenLiteConfirmation } from "./core/helpers/genlite-confirmation.class";
+import { GenLiteWebSocketPlugin } from './core/plugins/genlite-websocket.plugin';
 
 
 /** Official Plugins */
@@ -59,6 +60,9 @@ Press Cancel to Load, Press Okay to Stop.`;
     localStorage.setItem("GenLiteConfirms", confirmed);
 
     const genlite = new GenLite();
+    /** Exposes the most recently created WebSocket as window.genlite.socket */
+    await genlite.pluginLoader.addPlugin(GenLiteWebSocketPlugin);
+
     await genlite.init();
     window.genlite = genlite;
 


### PR DESCRIPTION
This exposes the most recently created WebSocket instance to window.genlite.socket, which would allow us to listen to it for messages rather than relying on NETWORK or such, this assumes NETWORK is an issue after the recent obfuscation trouble.