### PR TITLE
unpack that webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 node_modules
 dist
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GenLite 0.1.37 - For GenFanad
+# GenLite 0.1.39 - For GenFanad
 
 GenLite installation instructions
 1. Install [TamperMonkey(All Browsers)](https://www.tampermonkey.net/) in your browser of choice.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GenLite",
-  "version": "0.1.37",
+  "version": "0.1.39",
   "scripts": {
     "build:prod": "npm version patch --no-git-tag-version --force && npx webpack --mode production",
     "build:dev": "npx webpack --mode development",

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -36,16 +36,16 @@ export class GenLite {
     }
 
     async init() {
-        // this.installHook(Camera.prototype, 'update');
-        // this.installHook(Network.prototype, 'logoutOK');
-        // this.installHook(Network.prototype, 'disconnect', this.hookDisconnect)
-        // this.installHook(PhasedLoadingManager.prototype, 'start_phase', this.hookPhased);
-        // this.installHook(Network.prototype, 'action');
-        // this.installHook(Network.prototype, 'handle');
+        this.installHook(document.game.Camera, 'update');
+        this.installHook(document.game.Network, 'logoutOK');
+        this.installHook(document.game.Network, 'disconnect', this.hookDisconnect)
+        this.installHook(document.game.PhasedLoadingManager, 'start_phase', this.hookPhased);
+        this.installHook(document.game.Network, 'action');
+        this.installHook(document.game.Network, 'handle');
         // this.installHook(PlayerInfo.prototype, 'updateXP');
         // this.installHook(PlayerInfo.prototype, 'updateTooltip');
         // this.installHook(PlayerInfo.prototype, 'updateSkills');
-        this.installHook(window, 'initializeUI');
+        // this.installHook(window, 'initializeUI');
         // this.installHook(Game.prototype, 'combatUpdate');
         // this.installHook(PlayerHUD.prototype, 'setHealth');
         // this.installHook(Inventory.prototype, 'handleUpdatePacket');

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -45,10 +45,14 @@ export class GenLite {
         this.installHook(document.game.PlayerInfo.prototype, 'updateXP');
         this.installHook(document.game.PlayerInfo.prototype, 'updateTooltip');
         this.installHook(document.game.PlayerInfo.prototype, 'updateSkills');
-        // this.installHook(window, 'initializeUI');
+        // this no longer exists in genfanad: this.installHook(window, 'initializeUI');
         this.installHook(document.game.Game.prototype, 'combatUpdate');
         this.installHook(document.game.PlayerHUD.prototype, 'setHealth');
         this.installHook(document.game.Inventory.prototype, 'handleUpdatePacket');
+    }
+
+    onUIInitialized() {
+        this.hook('initializeUI');
     }
 
     hook(fnName: string, ...args: Array<unknown>) {

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -42,13 +42,13 @@ export class GenLite {
         this.installHook(document.game.PhasedLoadingManager, 'start_phase', this.hookPhased);
         this.installHook(document.game.Network, 'action');
         this.installHook(document.game.Network, 'handle');
-        // this.installHook(PlayerInfo.prototype, 'updateXP');
-        // this.installHook(PlayerInfo.prototype, 'updateTooltip');
-        // this.installHook(PlayerInfo.prototype, 'updateSkills');
+        this.installHook(document.game.PlayerInfo, 'updateXP');
+        this.installHook(document.game.PlayerInfo, 'updateTooltip');
+        this.installHook(document.game.PlayerInfo, 'updateSkills');
         // this.installHook(window, 'initializeUI');
-        // this.installHook(Game.prototype, 'combatUpdate');
-        // this.installHook(PlayerHUD.prototype, 'setHealth');
-        // this.installHook(Inventory.prototype, 'handleUpdatePacket');
+        this.installHook(document.game.Game, 'combatUpdate');
+        this.installHook(document.game.PlayerHUD, 'setHealth');
+        this.installHook(document.game.Inventory, 'handleUpdatePacket');
     }
 
     hook(fnName: string, ...args: Array<unknown>) {

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -36,19 +36,19 @@ export class GenLite {
     }
 
     async init() {
-        this.installHook(document.game.Camera, 'update');
-        this.installHook(document.game.Network, 'logoutOK');
-        this.installHook(document.game.Network, 'disconnect', this.hookDisconnect)
+        this.installHook(document.game.Camera.prototype, 'update');
+        this.installHook(document.game.Network.prototype, 'logoutOK');
+        this.installHook(document.game.Network.prototype, 'disconnect', this.hookDisconnect)
         this.installHook(document.game.PhasedLoadingManager, 'start_phase', this.hookPhased);
-        this.installHook(document.game.Network, 'action');
-        this.installHook(document.game.Network, 'handle');
-        this.installHook(document.game.PlayerInfo, 'updateXP');
-        this.installHook(document.game.PlayerInfo, 'updateTooltip');
-        this.installHook(document.game.PlayerInfo, 'updateSkills');
+        this.installHook(document.game.Network.prototype, 'action');
+        this.installHook(document.game.Network.prototype, 'handle');
+        this.installHook(document.game.PlayerInfo.prototype, 'updateXP');
+        this.installHook(document.game.PlayerInfo.prototype, 'updateTooltip');
+        this.installHook(document.game.PlayerInfo.prototype, 'updateSkills');
         // this.installHook(window, 'initializeUI');
-        this.installHook(document.game.Game, 'combatUpdate');
-        this.installHook(document.game.PlayerHUD, 'setHealth');
-        this.installHook(document.game.Inventory, 'handleUpdatePacket');
+        this.installHook(document.game.Game.prototype, 'combatUpdate');
+        this.installHook(document.game.PlayerHUD.prototype, 'setHealth');
+        this.installHook(document.game.Inventory.prototype, 'handleUpdatePacket');
     }
 
     hook(fnName: string, ...args: Array<unknown>) {

--- a/src/core/genlite.class.ts
+++ b/src/core/genlite.class.ts
@@ -36,19 +36,19 @@ export class GenLite {
     }
 
     async init() {
-        this.installHook(Camera.prototype, 'update');
-        this.installHook(Network.prototype, 'logoutOK');
-        this.installHook(Network.prototype, 'disconnect', this.hookDisconnect)
-        this.installHook(PhasedLoadingManager.prototype, 'start_phase', this.hookPhased);
-        this.installHook(Network.prototype, 'action');
-        this.installHook(Network.prototype, 'handle');
-        this.installHook(PlayerInfo.prototype, 'updateXP');
-        this.installHook(PlayerInfo.prototype, 'updateTooltip');
-        this.installHook(PlayerInfo.prototype, 'updateSkills');
+        // this.installHook(Camera.prototype, 'update');
+        // this.installHook(Network.prototype, 'logoutOK');
+        // this.installHook(Network.prototype, 'disconnect', this.hookDisconnect)
+        // this.installHook(PhasedLoadingManager.prototype, 'start_phase', this.hookPhased);
+        // this.installHook(Network.prototype, 'action');
+        // this.installHook(Network.prototype, 'handle');
+        // this.installHook(PlayerInfo.prototype, 'updateXP');
+        // this.installHook(PlayerInfo.prototype, 'updateTooltip');
+        // this.installHook(PlayerInfo.prototype, 'updateSkills');
         this.installHook(window, 'initializeUI');
-        this.installHook(Game.prototype, 'combatUpdate');
-        this.installHook(PlayerHUD.prototype, 'setHealth');
-        this.installHook(Inventory.prototype, 'handleUpdatePacket');
+        // this.installHook(Game.prototype, 'combatUpdate');
+        // this.installHook(PlayerHUD.prototype, 'setHealth');
+        // this.installHook(Inventory.prototype, 'handleUpdatePacket');
     }
 
     hook(fnName: string, ...args: Array<unknown>) {

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -26,19 +26,9 @@ declare interface CommandSpec {
 
 declare const ITEM_RIGHTCLICK_LIMIT: number;
 
-/** Library globals */
-declare const THREE: {
-    items: any,
-    [key: string]: any,
-};
-
 /** GenFanad specific globals */
 declare const GAME: {
     items: Record<string, typeof ItemStack>,
-    [key: string]: any,
-};
-
-declare const Game: {
     [key: string]: any,
 };
 
@@ -64,49 +54,13 @@ declare const PLAYER_INFO: {
     [key: string]: any,
 };
 
-declare const WorldManager: {
-    [key: string]: any,
-};
-
-declare const ItemStack: {
-    [key: string]: any,
-};
-
-declare const WORLDMANAGER: {
-    [key: string]: any,
-};
-
-declare const MUSIC_PLAYER: {
-    [key: string]: any,
-};
-
 declare const MUSIC_TRACK_NAMES: {
     [key: string]: string,
 };
 
-declare const GRAPHICS: {
-    [key: string]: any,
-};
-
 declare const SETTINGS: any;
 
-declare const PhasedLoadingManager: {
-    [key: string]: any,
-};
-
-declare const Network: {
-    [key: string]: any,
-};
-
-declare const Camera: {
-    [key: string]: any,
-};
-
 declare const PlayerInfo: {
-    [key: string]: any,
-};
-
-declare const CHAT: {
     [key: string]: any,
 };
 
@@ -114,15 +68,7 @@ declare const NETWORK: {
     [key: string]: any,
 };
 
-declare const Chat: {
-    [key: string]: any,
-};
-
 declare const NPC: {
-    [key: string]: any,
-}
-
-declare const PlayerHUD: {
     [key: string]: any,
 }
 
@@ -141,6 +87,6 @@ declare const KEYBOARD: {
 declare class SFXPlayer {
 }
 
-declare const Inventory: {
+declare const ItemStack: {
     [key: string]: any,
-};
+}

--- a/src/core/plugins/genlite-commands.plugin.ts
+++ b/src/core/plugins/genlite-commands.plugin.ts
@@ -8,7 +8,7 @@ export class GenLiteCommandsPlugin {
     async init() {
         window.genlite.registerPlugin(this);
 
-        this.originalProcessInput = Chat.prototype.processInput;
+        this.originalProcessInput = document.game.Chat.processInput;
         this.register("help", function (s) {
             if (!s) {
                 let helpStr = Object.keys(window.genlite.commands.commands).join(", ");
@@ -56,8 +56,8 @@ export class GenLiteCommandsPlugin {
     }
 
     public loginOK() {
-        CHAT.processInput = this.processInput.bind(
-            CHAT,
+        document.game.CHAT.processInput = this.processInput.bind(
+            document.game.CHAT,
             this,
             this.originalProcessInput,
         );
@@ -138,11 +138,11 @@ export class GenLiteCommandsPlugin {
     }
 
     public print(text: string) {
-        // CHAT.addGameMessage assigns directly to innerHTML. To avoid any
+        // document.game.CHAT.addGameMessage assigns directly to innerHTML. To avoid any
         // possible code injection, let text area do our string escaping.
         let e = document.createElement('textarea');
         e.textContent = text;
-        CHAT.addGameMessage(e.innerHTML);
+        document.game.CHAT.addGameMessage(e.innerHTML);
     }
 
 }

--- a/src/core/plugins/genlite-commands.plugin.ts
+++ b/src/core/plugins/genlite-commands.plugin.ts
@@ -142,7 +142,7 @@ export class GenLiteCommandsPlugin {
         // possible code injection, let text area do our string escaping.
         let e = document.createElement('textarea');
         e.textContent = text;
-        document.game.CHAT.addGameMessage(e.innerHTML);
+        document.game.Chat.addGameMessage(e.innerHTML);
     }
 
 }

--- a/src/core/plugins/genlite-settings.plugin.ts
+++ b/src/core/plugins/genlite-settings.plugin.ts
@@ -25,8 +25,8 @@ export class GenLiteSettingsPlugin {
         let searchBox = document.createElement("input");
         searchBox.type = "text";
         searchBox.onkeyup = (event) => { this.searchSettings.call(this, event) };
-        searchBox.onfocus = () => { CHAT.focus_locked = true; }
-        searchBox.onblur = () => { CHAT.focus_locked = false; }
+        searchBox.onfocus = () => { document.game.CHAT.focus_locked = true; }
+        searchBox.onblur = () => { document.game.CHAT.focus_locked = false; }
         searchBox.placeholder = "Settings Search";
         searchBox.id = "GenliteSettingsSearch";
         this.container.appendChild(searchBox);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { GenLite } from "./core/genlite.class";
 
 /** Official Plugins */
 // import { GenLiteVersionPlugin } from "./plugins/genlite-version.plugin";
-// import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
+import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
 // import { GenLiteChatPlugin } from "./plugins/genlite-chat.plugin";
 // import { GenLiteDropRecorderPlugin } from "./plugins/genlite-drop-recorder.plugin";
 // import { GenLiteInventoryPlugin } from "./plugins/genlite-inventory.plugin";
@@ -44,7 +44,9 @@ import { GenLite } from "./core/genlite.class";
 declare const GM_getResourceText : (s:string) => string;
 declare global {
     interface Document {
+        game: any;
         client: any;
+        initGenLite: () => void;
     }
 }
 
@@ -78,6 +80,17 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
     // localStorage.setItem("GenLiteConfirms", confirmed);
 
     async function initGenLite() {
+
+        document.game = {};
+        document.game.Camera = document.client.get('kS');
+        document.game.Network = document.client.get('iw');
+        document.game.PhasedLoadingManager = document.client.get('cS');
+        document.game.GRAPHICS = document.client.get('i.J4.graphics');
+        document.game.THREE = document.client.get('e');
+        document.game.THREE.Math = document.client.get('vi'); // TODO: is this right?
+        console.log('loaded game objects');
+        console.log(document.game);
+
         const genlite = new GenLite();
         await genlite.init();
         window.genlite = genlite;
@@ -89,7 +102,7 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
 
         /** Official Plugins */
         // await genlite.pluginLoader.addPlugin(GenLiteVersionPlugin);
-        // await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);
+        await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteChatPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteNPCHighlightPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
@@ -150,12 +163,14 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
 
     hookClient();
     window.addEventListener('load', (e) => {
+        document.initGenLite = initGenLite;
+
         let doc = (document as any)
         doc.client.set('document.client.originalStartScene', doc.client.get('NS'));
         doc.client.set('NS', function () {
             console.log('init genlite');
             document.client.originalStartScene();
-            // setTimeout(initGenLite, 100);
+            setTimeout(document.initGenLite, 100);
         });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 /*
-    Copyright (C) 2022-2023 Retoxified, dpeGit, FrozenReality
 */
 /*
     This file is part of GenLite.
@@ -25,10 +24,10 @@ import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
 // import { GenLiteChatPlugin } from "./plugins/genlite-chat.plugin";
 // import { GenLiteDropRecorderPlugin } from "./plugins/genlite-drop-recorder.plugin";
 // import { GenLiteInventoryPlugin } from "./plugins/genlite-inventory.plugin";
-// import { GenLiteItemHighlightPlugin } from "./plugins/genlite-item-highlight.plugin";
-// import { GenLiteNPCHighlightPlugin } from "./plugins/genlite-npc-highlight.plugin";
+import { GenLiteItemHighlightPlugin } from "./plugins/genlite-item-highlight.plugin";
+import { GenLiteNPCHighlightPlugin } from "./plugins/genlite-npc-highlight.plugin";
 // import { GenLiteRecipeRecorderPlugin } from "./plugins/genlite-recipe-recorder.plugin";
-// import { GenLiteWikiDataCollectionPlugin } from "./plugins/genlite-wiki-data-collection.plugin";
+import { GenLiteWikiDataCollectionPlugin } from "./plugins/genlite-wiki-data-collection.plugin";
 // import { GenLiteXpCalculator } from "./plugins/genlite-xp-calculator.plugin";
 // import { GenLiteHitRecorder } from "./plugins/genlite-hit-recorder.plugin";
 // import { GenLiteMenuScaler } from "./plugins/genlite-menu-scaler.plugin";
@@ -90,26 +89,34 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
         }
 
         document.game = {};
+        gameObject('CHAT', 'ex');
         gameObject('Camera', 'kS');
-        gameObject('Network', 'iw');
-        gameObject('PhasedLoadingManager', 'cS');
+        gameObject('Chat', '$x');
+        gameObject('DATA', 'qy');
         gameObject('GRAPHICS', 'i.J4.graphics');
+        gameObject('Game', 'Ug');
+        gameObject('GAME', 'jg.game');
+        gameObject('Inventory', 'Ex');
+        gameObject('INVENTORY', 'Zx');
+        gameObject('ItemStack', '_w');
+        gameObject('MUSIC_PLAYER', 'Ox');
+        gameObject('Network', 'iw');
+        gameObject('NETWORK', 'aw.network');
+        gameObject('PhasedLoadingManager', 'cS');
+        gameObject('Player', 'Ag');
+        gameObject('PLAYER', 'HS.player');
+        gameObject('PlayerHUD', 'kx');
+        gameObject('PlayerInfo', 'Hw');
+        gameObject('PLAYER_INFO', 'db');
         gameObject('THREE', 'e');
         gameObject('THREE.Math', 'vi'); // TODO: is this right?
-
-        gameObject('Game', 'Ug');
-        gameObject('PlayerHUD', 'kx');
-        gameObject('Inventory', 'Ex');
-        gameObject('PlayerInfo', 'Hw');
-        gameObject('Chat', '$x');
-        gameObject('CHAT', 'ex');
-        gameObject('WorldManager', 'bS');
         gameObject('WORLDMANAGER', 'yS');
-        gameObject('MUSIC_PLAYER', 'Ox');
+        gameObject('WorldManager', 'bS');
+        gameObject('ITEM_RIGHTCLICK_LIMIT', 'Os');
 
         const genlite = new GenLite();
-        await genlite.init();
         window.genlite = genlite;
+        await genlite.init();
 
         /** Core Features */
         genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
@@ -120,11 +127,11 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
         // await genlite.pluginLoader.addPlugin(GenLiteVersionPlugin);
         await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteChatPlugin);
-        // await genlite.pluginLoader.addPlugin(GenLiteNPCHighlightPlugin);
-        // await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
+        await genlite.pluginLoader.addPlugin(GenLiteNPCHighlightPlugin);
+        await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteInventoryPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteDropRecorderPlugin);
-        // await genlite.pluginLoader.addPlugin(GenLiteWikiDataCollectionPlugin);
+        await genlite.pluginLoader.addPlugin(GenLiteWikiDataCollectionPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteXpCalculator);
         // await genlite.pluginLoader.addPlugin(GenLiteRecipeRecorderPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteHitRecorder);
@@ -139,8 +146,8 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
         // await genlite.pluginLoader.addPlugin(GenLiteHighscores);
 
         /** post init things */
-        // await window.GenLiteSettingsPlugin.postInit();
-        // await window.GenLiteNPCHighlightPlugin.postInit();
+        await window.GenLiteSettingsPlugin.postInit();
+        await window.GenLiteNPCHighlightPlugin.postInit();
         // await window.GenLiteDropRecorderPlugin.postInit();
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { GenLiteItemHighlightPlugin } from "./plugins/genlite-item-highlight.plu
 import { GenLiteNPCHighlightPlugin } from "./plugins/genlite-npc-highlight.plugin";
 // import { GenLiteRecipeRecorderPlugin } from "./plugins/genlite-recipe-recorder.plugin";
 import { GenLiteWikiDataCollectionPlugin } from "./plugins/genlite-wiki-data-collection.plugin";
-// import { GenLiteXpCalculator } from "./plugins/genlite-xp-calculator.plugin";
+import { GenLiteXpCalculator } from "./plugins/genlite-xp-calculator.plugin";
 // import { GenLiteHitRecorder } from "./plugins/genlite-hit-recorder.plugin";
 // import { GenLiteMenuScaler } from "./plugins/genlite-menu-scaler.plugin";
 // import { GenLiteMusicPlugin } from "./plugins/genlite-music.plugin";
@@ -132,7 +132,7 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
         // await genlite.pluginLoader.addPlugin(GenLiteInventoryPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteDropRecorderPlugin);
         await genlite.pluginLoader.addPlugin(GenLiteWikiDataCollectionPlugin);
-        // await genlite.pluginLoader.addPlugin(GenLiteXpCalculator);
+        await genlite.pluginLoader.addPlugin(GenLiteXpCalculator);
         // await genlite.pluginLoader.addPlugin(GenLiteRecipeRecorderPlugin);
         // await genlite.pluginLoader.addPlugin(GenLiteHitRecorder);
         // await genlite.pluginLoader.addPlugin(GenLiteMenuScaler);
@@ -149,6 +149,16 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
         await window.GenLiteSettingsPlugin.postInit();
         await window.GenLiteNPCHighlightPlugin.postInit();
         // await window.GenLiteDropRecorderPlugin.postInit();
+
+        // NOTE: currently initGenlite is called after the scene has started
+        //       (in minified function NS). The initializeUI function does not
+        //       exist in genfanad and is inlined in NS. So at this point, UI
+        //       is already initialized and we update the plugins.
+        //
+        //       We should eventually move genlite to init at page start, then
+        //       this needs to move to the NS override at the bottom of this
+        //       file.
+        genlite.onUIInitialized();
     }
 
     function firefoxOverride(e) {
@@ -191,7 +201,6 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
         let doc = (document as any)
         doc.client.set('document.client.originalStartScene', doc.client.get('NS'));
         doc.client.set('NS', function () {
-            console.log('init genlite');
             document.client.originalStartScene();
             setTimeout(document.initGenLite, 100);
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,34 +13,35 @@
 
 /** Core Features */
 import { GenLite } from "./core/genlite.class";
-import { GenLiteNotificationPlugin } from "./core/plugins/genlite-notification.plugin";
-import { GenLiteSettingsPlugin } from "./core/plugins/genlite-settings.plugin";
-import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
-import { GenLiteConfirmation } from "./core/helpers/genlite-confirmation.class";
+// import { GenLiteNotificationPlugin } from "./core/plugins/genlite-notification.plugin";
+// import { GenLiteSettingsPlugin } from "./core/plugins/genlite-settings.plugin";
+// import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
+// import { GenLiteConfirmation } from "./core/helpers/genlite-confirmation.class";
 
 
 /** Official Plugins */
-import { GenLiteVersionPlugin } from "./plugins/genlite-version.plugin";
-import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
-import { GenLiteChatPlugin } from "./plugins/genlite-chat.plugin";
-import { GenLiteDropRecorderPlugin } from "./plugins/genlite-drop-recorder.plugin";
-import { GenLiteInventoryPlugin } from "./plugins/genlite-inventory.plugin";
-import { GenLiteItemHighlightPlugin } from "./plugins/genlite-item-highlight.plugin";
-import { GenLiteNPCHighlightPlugin } from "./plugins/genlite-npc-highlight.plugin";
-import { GenLiteRecipeRecorderPlugin } from "./plugins/genlite-recipe-recorder.plugin";
-import { GenLiteWikiDataCollectionPlugin } from "./plugins/genlite-wiki-data-collection.plugin";
-import { GenLiteXpCalculator } from "./plugins/genlite-xp-calculator.plugin";
-import { GenLiteHitRecorder } from "./plugins/genlite-hit-recorder.plugin";
-import { GenLiteMenuScaler } from "./plugins/genlite-menu-scaler.plugin";
-import { GenLiteMusicPlugin } from "./plugins/genlite-music.plugin";
-import { GenLiteLocationsPlugin } from "./plugins/genlite-locations.plugin";
-import { GenLiteMenuSwapperPlugin } from "./plugins/genlite-menuswapper.plugin";
-import { GenLiteItemTooltips } from "./plugins/genlite-item-tooltips.plugin";
-import { GenLiteSoundNotification } from "./plugins/genlite-sound-notification.plugin";
-import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand.plugin";
-import { GenLitePlayerToolsPlugin }  from "./plugins/genlite-playertools.plugin";
-import { GenLiteHighscores } from "./plugins/genlite-highscores.plugin";
+// import { GenLiteVersionPlugin } from "./plugins/genlite-version.plugin";
+// import { GenLiteCameraPlugin } from "./plugins/genlite-camera.plugin";
+// import { GenLiteChatPlugin } from "./plugins/genlite-chat.plugin";
+// import { GenLiteDropRecorderPlugin } from "./plugins/genlite-drop-recorder.plugin";
+// import { GenLiteInventoryPlugin } from "./plugins/genlite-inventory.plugin";
+// import { GenLiteItemHighlightPlugin } from "./plugins/genlite-item-highlight.plugin";
+// import { GenLiteNPCHighlightPlugin } from "./plugins/genlite-npc-highlight.plugin";
+// import { GenLiteRecipeRecorderPlugin } from "./plugins/genlite-recipe-recorder.plugin";
+// import { GenLiteWikiDataCollectionPlugin } from "./plugins/genlite-wiki-data-collection.plugin";
+// import { GenLiteXpCalculator } from "./plugins/genlite-xp-calculator.plugin";
+// import { GenLiteHitRecorder } from "./plugins/genlite-hit-recorder.plugin";
+// import { GenLiteMenuScaler } from "./plugins/genlite-menu-scaler.plugin";
+// import { GenLiteMusicPlugin } from "./plugins/genlite-music.plugin";
+// import { GenLiteLocationsPlugin } from "./plugins/genlite-locations.plugin";
+// import { GenLiteMenuSwapperPlugin } from "./plugins/genlite-menuswapper.plugin";
+// import { GenLiteItemTooltips } from "./plugins/genlite-item-tooltips.plugin";
+// import { GenLiteSoundNotification } from "./plugins/genlite-sound-notification.plugin";
+// import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand.plugin";
+// import { GenLitePlayerToolsPlugin }  from "./plugins/genlite-playertools.plugin";
+// import { GenLiteHighscores } from "./plugins/genlite-highscores.plugin";
 
+declare const GM_getResourceText : (s:string) => string;
 
 const DISCLAIMER = `
 GenLite is NOT associated with Rose-Tinted Games.
@@ -51,49 +52,99 @@ If you find a bug and are unsure post in the GenLite Server. We will help you.
 While we work to ensure compatibility, Use At Your Own Risk.
 Press Cancel to Load, Press Okay to Stop.`;
 
+const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+
 (async function load() {
-    let confirmed = localStorage.getItem("GenLiteConfirms");
-    if (!confirmed && await GenLiteConfirmation.confirm(DISCLAIMER) === true)
-        return;
-    confirmed = "true";
-    localStorage.setItem("GenLiteConfirms", confirmed);
+    // let confirmed = localStorage.getItem("GenLiteConfirms");
+    // if (!confirmed && await GenLiteConfirmation.confirm(DISCLAIMER) === true)
+    //     return;
+    // confirmed = "true";
+    // localStorage.setItem("GenLiteConfirms", confirmed);
 
-    const genlite = new GenLite();
-    await genlite.init();
-    window.genlite = genlite;
+    async function setupGenLite() {
+        const genlite = new GenLite();
+        await genlite.init();
+        window.genlite = genlite;
 
-    /** Core Features */
-    genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
-    genlite.settings = await genlite.pluginLoader.addPlugin(GenLiteSettingsPlugin);
-    genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
+        /** Core Features */
+        // genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
+        // genlite.settings = await genlite.pluginLoader.addPlugin(GenLiteSettingsPlugin);
+        // genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
 
-    /** Official Plugins */
-    await genlite.pluginLoader.addPlugin(GenLiteVersionPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteChatPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteNPCHighlightPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteInventoryPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteDropRecorderPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteWikiDataCollectionPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteXpCalculator);
-    await genlite.pluginLoader.addPlugin(GenLiteRecipeRecorderPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteHitRecorder);
-    await genlite.pluginLoader.addPlugin(GenLiteMenuScaler);
-    await genlite.pluginLoader.addPlugin(GenLiteMusicPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteLocationsPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteMenuSwapperPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteItemTooltips);
-    await genlite.pluginLoader.addPlugin(GenLiteSoundNotification);
-    await genlite.pluginLoader.addPlugin(GenLiteGeneralChatCommands);
-    await genlite.pluginLoader.addPlugin(GenLitePlayerToolsPlugin);
-    await genlite.pluginLoader.addPlugin(GenLiteHighscores);
+        /** Official Plugins */
+        // await genlite.pluginLoader.addPlugin(GenLiteVersionPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteCameraPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteChatPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteNPCHighlightPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteItemHighlightPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteInventoryPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteDropRecorderPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteWikiDataCollectionPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteXpCalculator);
+        // await genlite.pluginLoader.addPlugin(GenLiteRecipeRecorderPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteHitRecorder);
+        // await genlite.pluginLoader.addPlugin(GenLiteMenuScaler);
+        // await genlite.pluginLoader.addPlugin(GenLiteMusicPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteLocationsPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteMenuSwapperPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteItemTooltips);
+        // await genlite.pluginLoader.addPlugin(GenLiteSoundNotification);
+        // await genlite.pluginLoader.addPlugin(GenLiteGeneralChatCommands);
+        // await genlite.pluginLoader.addPlugin(GenLitePlayerToolsPlugin);
+        // await genlite.pluginLoader.addPlugin(GenLiteHighscores);
 
-    /** post init things */
-    await window.GenLiteSettingsPlugin.postInit();
-    await window.GenLiteNPCHighlightPlugin.postInit();
-    await window.GenLiteDropRecorderPlugin.postInit();
+        /** post init things */
+        // await window.GenLiteSettingsPlugin.postInit();
+        // await window.GenLiteNPCHighlightPlugin.postInit();
+        // await window.GenLiteDropRecorderPlugin.postInit();
+    }
 
-}
-)();
+    function firefoxOverride(e) {
+        let src = e.target.src;
+        if (src === 'https://play.genfanad.com/play/js/client.js') {
+            e.preventDefault(); // do not load
+            e.stopPropagation();
+            var script = document.createElement('script');
+            script.textContent = scriptText;
+            script.type = 'module';
+            (document.head||document.documentElement).appendChild(script);
+        }
+    }
 
+    function hookClient() {
+
+        if (document.head) {
+            throw new Error('Head already exists - make sure to enable instant script injection');
+        }
+
+        let scriptText = GM_getResourceText('clientjs');
+        scriptText = scriptText.substring(0, scriptText.length - 5)
+            + "; document.client = {};"
+            + "document.client.get = function(a) {"
+            +   "return eval(a);"
+            + "};"
+            + "document.client.set = function(a, b) {"
+            +   "eval(a + ' = ' + b);"
+            + "};"
+            + scriptText.substring(scriptText.length-5);
+
+        if (isFirefox) {
+            document.addEventListener("beforescriptexecute", firefoxOverride, true);
+        } else {
+            new MutationObserver((_, observer) => {
+                const clientjsScriptTag = document.querySelector('script[src*="client.js"]');
+                if (clientjsScriptTag) {
+                    clientjsScriptTag.remove();
+                    // clientjsScriptTag.removeAttribute('src');
+                    // clientjsScriptTag.textContent = scriptText;
+                }
+            }).observe(document.documentElement, {
+                childList: true,
+                subtree: true
+            });
+        }
+    }
+
+    hookClient();
+
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,10 @@
 
 /** Core Features */
 import { GenLite } from "./core/genlite.class";
-// import { GenLiteNotificationPlugin } from "./core/plugins/genlite-notification.plugin";
-// import { GenLiteSettingsPlugin } from "./core/plugins/genlite-settings.plugin";
-// import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
-// import { GenLiteConfirmation } from "./core/helpers/genlite-confirmation.class";
+import { GenLiteNotificationPlugin } from "./core/plugins/genlite-notification.plugin";
+import { GenLiteSettingsPlugin } from "./core/plugins/genlite-settings.plugin";
+import { GenLiteCommandsPlugin } from "./core/plugins/genlite-commands.plugin";
+import { GenLiteConfirmation } from "./core/helpers/genlite-confirmation.class";
 
 
 /** Official Plugins */
@@ -73,32 +73,48 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
     + scriptText.substring(scriptText.length-5);
 
 (async function load() {
-    // let confirmed = localStorage.getItem("GenLiteConfirms");
-    // if (!confirmed && await GenLiteConfirmation.confirm(DISCLAIMER) === true)
-    //     return;
-    // confirmed = "true";
-    // localStorage.setItem("GenLiteConfirms", confirmed);
+    let confirmed = localStorage.getItem("GenLiteConfirms");
+    if (!confirmed && await GenLiteConfirmation.confirm(DISCLAIMER) === true)
+        return;
+    confirmed = "true";
+    localStorage.setItem("GenLiteConfirms", confirmed);
 
     async function initGenLite() {
 
+        function gameObject(name: string, minified: string): any {
+            var o = document.client.get(minified);
+            if (!o) {
+                console.log(`${minified} (${name}) is not defined: ${o}`);
+            }
+            document.game[name] = o;
+        }
+
         document.game = {};
-        document.game.Camera = document.client.get('kS');
-        document.game.Network = document.client.get('iw');
-        document.game.PhasedLoadingManager = document.client.get('cS');
-        document.game.GRAPHICS = document.client.get('i.J4.graphics');
-        document.game.THREE = document.client.get('e');
-        document.game.THREE.Math = document.client.get('vi'); // TODO: is this right?
-        console.log('loaded game objects');
-        console.log(document.game);
+        gameObject('Camera', 'kS');
+        gameObject('Network', 'iw');
+        gameObject('PhasedLoadingManager', 'cS');
+        gameObject('GRAPHICS', 'i.J4.graphics');
+        gameObject('THREE', 'e');
+        gameObject('THREE.Math', 'vi'); // TODO: is this right?
+
+        gameObject('Game', 'Ug');
+        gameObject('PlayerHUD', 'kx');
+        gameObject('Inventory', 'Ex');
+        gameObject('PlayerInfo', 'Hw');
+        gameObject('Chat', '$x');
+        gameObject('CHAT', 'ex');
+        gameObject('WorldManager', 'bS');
+        gameObject('WORLDMANAGER', 'yS');
+        gameObject('MUSIC_PLAYER', 'Ox');
 
         const genlite = new GenLite();
         await genlite.init();
         window.genlite = genlite;
 
         /** Core Features */
-        // genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
-        // genlite.settings = await genlite.pluginLoader.addPlugin(GenLiteSettingsPlugin);
-        // genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
+        genlite.notifications = await genlite.pluginLoader.addPlugin(GenLiteNotificationPlugin);
+        genlite.settings = await genlite.pluginLoader.addPlugin(GenLiteSettingsPlugin);
+        genlite.commands = await genlite.pluginLoader.addPlugin(GenLiteCommandsPlugin);
 
         /** Official Plugins */
         // await genlite.pluginLoader.addPlugin(GenLiteVersionPlugin);

--- a/src/plugins/genlite-camera.plugin.ts
+++ b/src/plugins/genlite-camera.plugin.ts
@@ -34,97 +34,97 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
 
     originalCameraMode: Function;
 
-    unlockCamera: boolean = true;
-    hideRoofs: boolean = true;
+    unlockCamera: boolean = false;
+    hideRoofs: boolean = false;
     maxDistance: Number = 15;
     minDistance: Number = Math.PI;
 
     renderDistance: number = 65;
-    distanceFog: boolean = true;
+    distanceFog: boolean = false;
     fogLevel: number = 0.5;
-    skyboxEnabled: boolean = true;
+    skyboxEnabled: boolean = false;
     skybox: any = null;
 
     async init() {
         window.genlite.registerPlugin(this);
 
-        // this.originalCameraMode = WorldManager.prototype.updatePlayerTile;
+        this.originalCameraMode = document.game.WorldManager.updatePlayerTile;
 
-        // this.unlockCamera = window.genlite.settings.add("Camera.UnlockCam", true, "Unlock Camera", "checkbox", this.handleUnlockCameraToggle, this);
-        // this.hideRoofs = window.genlite.settings.add("Camera.HideRoofs", true, "Hide Roofs", "checkbox", this.handleHideRoofToggle, this);
-        // this.maxDistance = parseInt(window.genlite.settings.add(
-        //     "Camera.maxDistance",
-        //     "15",
-        //     "Max Distance: <div style=\"display: contents;\" id=\"GenLiteMaxDistanceOutput\"></div>",
-        //     "range",
-        //     this.handleMaxDistance,
-        //     this,
-        //     undefined,
-        //     [
-        //         ["min", "8"],
-        //         ["max", "32"],
-        //         ["step", "1"],
-        //         ["value", "15"],
-        //         ["class", "gen-slider"]
-        //     ], "Camera.UnlockCam"
-        // ));
-        // document.getElementById("GenLiteMaxDistanceOutput").innerHTML = this.maxDistance.toString();
-        // this.minDistance = parseInt(window.genlite.settings.add(
-        //     "Camera.minDistance",
-        //     "3.14",
-        //     "Min Distance: <div style=\"display: contents;\" id=\"GenLiteMinDistanceOutput\"></div>",
-        //     "range",
-        //     this.handleMinDistance,
-        //     this,
-        //     undefined,
-        //     [
-        //         ["min", "0"],
-        //         ["max", "8"],
-        //         ["step", "1"],
-        //         ["value", "3.14"],
-        //         ["class", "gen-slider"]
-        //     ], "Camera.UnlockCam"
-        // ));
-        // document.getElementById("GenLiteMinDistanceOutput").innerHTML = this.minDistance.toString();
-        // this.skyboxEnabled = window.genlite.settings.add("Camera.Skybox", true, "Skybox", "checkbox", this.handleSkybox, this);
-        // this.distanceFog = window.genlite.settings.add("Camera.Fog", true, "Fog", "checkbox", this.handleFog, this);
-        // this.fogLevel = parseFloat(window.genlite.settings.add(
-        //     "Camera.FogLevel",
-        //     GenLiteCameraPlugin.defaultFogLevel.toString(),
-        //     "Fog Level",
-        //     "range",
-        //     function (v) {
-        //         this.handleFogLevel(parseFloat(v));
-        //     },
-        //     this,
-        //     undefined,
-        //     [
-        //         ["min", GenLiteCameraPlugin.minFogLevel.toString()],
-        //         ["max", GenLiteCameraPlugin.maxFogLevel.toString()],
-        //         ["value", GenLiteCameraPlugin.defaultFogLevel.toString()],
-        //         ["class", "gen-slider"],
-        //         ["step", "0.05"],
-        //     ],
-        //     this.distanceFog
-        // ));
-        // this.renderDistance = parseFloat(window.genlite.settings.add(
-        //     "Camera.RenderDistance",
-        //     GenLiteCameraPlugin.defaultRenderDistance.toString(),
-        //     "Render Distance",
-        //     "range",
-        //     function (v) {
-        //         this.handleRenderDistance(parseFloat(v));
-        //     },
-        //     this,
-        //     undefined,
-        //     [
-        //         ["min", GenLiteCameraPlugin.minRenderDistance.toString()],
-        //         ["max", GenLiteCameraPlugin.maxRenderDistance.toString()],
-        //         ["value", GenLiteCameraPlugin.defaultRenderDistance.toString()],
-        //         ["class", "gen-slider"],
-        //         ["step", "5"],
-        //     ]
-        // ));
+        this.unlockCamera = window.genlite.settings.add("Camera.UnlockCam", true, "Unlock Camera", "checkbox", this.handleUnlockCameraToggle, this);
+        this.hideRoofs = window.genlite.settings.add("Camera.HideRoofs", true, "Hide Roofs", "checkbox", this.handleHideRoofToggle, this);
+        this.maxDistance = parseInt(window.genlite.settings.add(
+            "Camera.maxDistance",
+            "15",
+            "Max Distance: <div style=\"display: contents;\" id=\"GenLiteMaxDistanceOutput\"></div>",
+            "range",
+            this.handleMaxDistance,
+            this,
+            undefined,
+            [
+                ["min", "8"],
+                ["max", "32"],
+                ["step", "1"],
+                ["value", "15"],
+                ["class", "gen-slider"]
+            ], "Camera.UnlockCam"
+        ));
+        document.getElementById("GenLiteMaxDistanceOutput").innerHTML = this.maxDistance.toString();
+        this.minDistance = parseInt(window.genlite.settings.add(
+            "Camera.minDistance",
+            "3.14",
+            "Min Distance: <div style=\"display: contents;\" id=\"GenLiteMinDistanceOutput\"></div>",
+            "range",
+            this.handleMinDistance,
+            this,
+            undefined,
+            [
+                ["min", "0"],
+                ["max", "8"],
+                ["step", "1"],
+                ["value", "3.14"],
+                ["class", "gen-slider"]
+            ], "Camera.UnlockCam"
+        ));
+        document.getElementById("GenLiteMinDistanceOutput").innerHTML = this.minDistance.toString();
+        this.skyboxEnabled = window.genlite.settings.add("Camera.Skybox", true, "Skybox", "checkbox", this.handleSkybox, this);
+        this.distanceFog = window.genlite.settings.add("Camera.Fog", true, "Fog", "checkbox", this.handleFog, this);
+        this.fogLevel = parseFloat(window.genlite.settings.add(
+            "Camera.FogLevel",
+            GenLiteCameraPlugin.defaultFogLevel.toString(),
+            "Fog Level",
+            "range",
+            function (v) {
+                this.handleFogLevel(parseFloat(v));
+            },
+            this,
+            undefined,
+            [
+                ["min", GenLiteCameraPlugin.minFogLevel.toString()],
+                ["max", GenLiteCameraPlugin.maxFogLevel.toString()],
+                ["value", GenLiteCameraPlugin.defaultFogLevel.toString()],
+                ["class", "gen-slider"],
+                ["step", "0.05"],
+            ],
+            this.distanceFog
+        ));
+        this.renderDistance = parseFloat(window.genlite.settings.add(
+            "Camera.RenderDistance",
+            GenLiteCameraPlugin.defaultRenderDistance.toString(),
+            "Render Distance",
+            "range",
+            function (v) {
+                this.handleRenderDistance(parseFloat(v));
+            },
+            this,
+            undefined,
+            [
+                ["min", GenLiteCameraPlugin.minRenderDistance.toString()],
+                ["max", GenLiteCameraPlugin.maxRenderDistance.toString()],
+                ["value", GenLiteCameraPlugin.defaultRenderDistance.toString()],
+                ["class", "gen-slider"],
+                ["step", "5"],
+            ]
+        ));
     }
 
     handleUnlockCameraToggle(state: boolean) {
@@ -222,14 +222,14 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
     }
 
     setCameraMode() {
-        // if (WORLDMANAGER !== undefined) {
-        //     if (this.hideRoofs === true) {
-        //         WORLDMANAGER.updatePlayerTile = this.noRoofCameraMode.bind(WORLDMANAGER);
-        //     } else {
-        //         WORLDMANAGER.updatePlayerTile = this.originalCameraMode.bind(WORLDMANAGER);
-        //     }
-        //     WORLDMANAGER.updatePlayerTile.call(WORLDMANAGER);
-        // }
+        if (document.game.WORLDMANAGER !== undefined) {
+            if (this.hideRoofs === true) {
+                document.game.WORLDMANAGER.updatePlayerTile = this.noRoofCameraMode.bind(document.game.WORLDMANAGER);
+            } else {
+                document.game.WORLDMANAGER.updatePlayerTile = this.originalCameraMode.bind(document.game.WORLDMANAGER);
+            }
+            document.game.WORLDMANAGER.updatePlayerTile.call(document.game.WORLDMANAGER);
+        }
 
         if (document.game.GRAPHICS !== undefined) {
             if (this.unlockCamera === true) {
@@ -245,25 +245,25 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
             }
         }
     }
-    // noRoofCameraMode() {
-    //     const self = (this as any);
+    noRoofCameraMode() {
+        const self = (this as any);
 
-    //     let tile = self.loadedSegments[self.segmentKey].getTile(self.segment.lx, self.segment.ly)
-    //     if (!tile)
-    //         throw `Invalid location: ${self.segmentKey} ${self.segment.lx}, ${self.segment.ly}`
-    //     self.indoors = true;
-    //     for (let i in self.loadedSegments) {
-    //         self.loadedSegments[i].setIndoorStatus(self.indoors);
-    //     }
-    //     if (tile.pvp) {
-    //         let pvp = document.getElementById('pvp_indicator');
-    //         pvp.style.display = 'block';
-    //         pvp.innerText = "PvP Level: YES";
-    //         self.pvp_zone = true;
-    //     } else {
-    //         document.getElementById('pvp_indicator').style.display = 'none';
-    //         self.pvp_zone = false;
-    //     }
-    //     MUSIC_PLAYER.setNextTrack(tile.music);
-    // }
+        let tile = self.loadedSegments[self.segmentKey].getTile(self.segment.lx, self.segment.ly)
+        if (!tile)
+            throw `Invalid location: ${self.segmentKey} ${self.segment.lx}, ${self.segment.ly}`
+        self.indoors = true;
+        for (let i in self.loadedSegments) {
+            self.loadedSegments[i].setIndoorStatus(self.indoors);
+        }
+        if (tile.pvp) {
+            let pvp = document.getElementById('pvp_indicator');
+            pvp.style.display = 'block';
+            pvp.innerText = "PvP Level: YES";
+            self.pvp_zone = true;
+        } else {
+            document.getElementById('pvp_indicator').style.display = 'none';
+            self.pvp_zone = false;
+        }
+        document.game.MUSIC_PLAYER.setNextTrack(tile.music);
+    }
 }

--- a/src/plugins/genlite-camera.plugin.ts
+++ b/src/plugins/genlite-camera.plugin.ts
@@ -48,83 +48,83 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
     async init() {
         window.genlite.registerPlugin(this);
 
-        this.originalCameraMode = WorldManager.prototype.updatePlayerTile;
+        // this.originalCameraMode = WorldManager.prototype.updatePlayerTile;
 
-        this.unlockCamera = window.genlite.settings.add("Camera.UnlockCam", true, "Unlock Camera", "checkbox", this.handleUnlockCameraToggle, this);
-        this.hideRoofs = window.genlite.settings.add("Camera.HideRoofs", true, "Hide Roofs", "checkbox", this.handleHideRoofToggle, this);
-        this.maxDistance = parseInt(window.genlite.settings.add(
-            "Camera.maxDistance",
-            "15",
-            "Max Distance: <div style=\"display: contents;\" id=\"GenLiteMaxDistanceOutput\"></div>",
-            "range",
-            this.handleMaxDistance,
-            this,
-            undefined,
-            [
-                ["min", "8"],
-                ["max", "32"],
-                ["step", "1"],
-                ["value", "15"],
-                ["class", "gen-slider"]
-            ], "Camera.UnlockCam"
-        ));
-        document.getElementById("GenLiteMaxDistanceOutput").innerHTML = this.maxDistance.toString();
-        this.minDistance = parseInt(window.genlite.settings.add(
-            "Camera.minDistance",
-            "3.14",
-            "Min Distance: <div style=\"display: contents;\" id=\"GenLiteMinDistanceOutput\"></div>",
-            "range",
-            this.handleMinDistance,
-            this,
-            undefined,
-            [
-                ["min", "0"],
-                ["max", "8"],
-                ["step", "1"],
-                ["value", "3.14"],
-                ["class", "gen-slider"]
-            ], "Camera.UnlockCam"
-        ));
-        document.getElementById("GenLiteMinDistanceOutput").innerHTML = this.minDistance.toString();
-        this.skyboxEnabled = window.genlite.settings.add("Camera.Skybox", true, "Skybox", "checkbox", this.handleSkybox, this);
-        this.distanceFog = window.genlite.settings.add("Camera.Fog", true, "Fog", "checkbox", this.handleFog, this);
-        this.fogLevel = parseFloat(window.genlite.settings.add(
-            "Camera.FogLevel",
-            GenLiteCameraPlugin.defaultFogLevel.toString(),
-            "Fog Level",
-            "range",
-            function (v) {
-                this.handleFogLevel(parseFloat(v));
-            },
-            this,
-            undefined,
-            [
-                ["min", GenLiteCameraPlugin.minFogLevel.toString()],
-                ["max", GenLiteCameraPlugin.maxFogLevel.toString()],
-                ["value", GenLiteCameraPlugin.defaultFogLevel.toString()],
-                ["class", "gen-slider"],
-                ["step", "0.05"],
-            ],
-            this.distanceFog
-        ));
-        this.renderDistance = parseFloat(window.genlite.settings.add(
-            "Camera.RenderDistance",
-            GenLiteCameraPlugin.defaultRenderDistance.toString(),
-            "Render Distance",
-            "range",
-            function (v) {
-                this.handleRenderDistance(parseFloat(v));
-            },
-            this,
-            undefined,
-            [
-                ["min", GenLiteCameraPlugin.minRenderDistance.toString()],
-                ["max", GenLiteCameraPlugin.maxRenderDistance.toString()],
-                ["value", GenLiteCameraPlugin.defaultRenderDistance.toString()],
-                ["class", "gen-slider"],
-                ["step", "5"],
-            ]
-        ));
+        // this.unlockCamera = window.genlite.settings.add("Camera.UnlockCam", true, "Unlock Camera", "checkbox", this.handleUnlockCameraToggle, this);
+        // this.hideRoofs = window.genlite.settings.add("Camera.HideRoofs", true, "Hide Roofs", "checkbox", this.handleHideRoofToggle, this);
+        // this.maxDistance = parseInt(window.genlite.settings.add(
+        //     "Camera.maxDistance",
+        //     "15",
+        //     "Max Distance: <div style=\"display: contents;\" id=\"GenLiteMaxDistanceOutput\"></div>",
+        //     "range",
+        //     this.handleMaxDistance,
+        //     this,
+        //     undefined,
+        //     [
+        //         ["min", "8"],
+        //         ["max", "32"],
+        //         ["step", "1"],
+        //         ["value", "15"],
+        //         ["class", "gen-slider"]
+        //     ], "Camera.UnlockCam"
+        // ));
+        // document.getElementById("GenLiteMaxDistanceOutput").innerHTML = this.maxDistance.toString();
+        // this.minDistance = parseInt(window.genlite.settings.add(
+        //     "Camera.minDistance",
+        //     "3.14",
+        //     "Min Distance: <div style=\"display: contents;\" id=\"GenLiteMinDistanceOutput\"></div>",
+        //     "range",
+        //     this.handleMinDistance,
+        //     this,
+        //     undefined,
+        //     [
+        //         ["min", "0"],
+        //         ["max", "8"],
+        //         ["step", "1"],
+        //         ["value", "3.14"],
+        //         ["class", "gen-slider"]
+        //     ], "Camera.UnlockCam"
+        // ));
+        // document.getElementById("GenLiteMinDistanceOutput").innerHTML = this.minDistance.toString();
+        // this.skyboxEnabled = window.genlite.settings.add("Camera.Skybox", true, "Skybox", "checkbox", this.handleSkybox, this);
+        // this.distanceFog = window.genlite.settings.add("Camera.Fog", true, "Fog", "checkbox", this.handleFog, this);
+        // this.fogLevel = parseFloat(window.genlite.settings.add(
+        //     "Camera.FogLevel",
+        //     GenLiteCameraPlugin.defaultFogLevel.toString(),
+        //     "Fog Level",
+        //     "range",
+        //     function (v) {
+        //         this.handleFogLevel(parseFloat(v));
+        //     },
+        //     this,
+        //     undefined,
+        //     [
+        //         ["min", GenLiteCameraPlugin.minFogLevel.toString()],
+        //         ["max", GenLiteCameraPlugin.maxFogLevel.toString()],
+        //         ["value", GenLiteCameraPlugin.defaultFogLevel.toString()],
+        //         ["class", "gen-slider"],
+        //         ["step", "0.05"],
+        //     ],
+        //     this.distanceFog
+        // ));
+        // this.renderDistance = parseFloat(window.genlite.settings.add(
+        //     "Camera.RenderDistance",
+        //     GenLiteCameraPlugin.defaultRenderDistance.toString(),
+        //     "Render Distance",
+        //     "range",
+        //     function (v) {
+        //         this.handleRenderDistance(parseFloat(v));
+        //     },
+        //     this,
+        //     undefined,
+        //     [
+        //         ["min", GenLiteCameraPlugin.minRenderDistance.toString()],
+        //         ["max", GenLiteCameraPlugin.maxRenderDistance.toString()],
+        //         ["value", GenLiteCameraPlugin.defaultRenderDistance.toString()],
+        //         ["class", "gen-slider"],
+        //         ["step", "5"],
+        //     ]
+        // ));
     }
 
     handleUnlockCameraToggle(state: boolean) {
@@ -150,18 +150,18 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
 
     handleRenderDistance(value: number) {
         this.renderDistance = value;
-        GRAPHICS.camera.camera.far = value;
-        GRAPHICS.camera.camera.updateProjectionMatrix();
+        window.GRAPHICS.camera.camera.far = value;
+        window.GRAPHICS.camera.camera.updateProjectionMatrix();
 
         // genfanad does a bit of it's own object pruning, so we update that
         // distance as well Then we need to iterate over every object and
         // render the newly visible ones, because by default this would only
         // occur when the player moves.
-        GRAPHICS.scene.dd2 = value * value;
-        for (let i in GRAPHICS.scene.allObjects) {
-            let o = GRAPHICS.scene.allObjects[i];
-            if (GRAPHICS.scene.checkObject(o)) {
-                GRAPHICS.scene.showObject(i);
+        window.GRAPHICS.scene.dd2 = value * value;
+        for (let i in window.GRAPHICS.scene.allObjects) {
+            let o = window.GRAPHICS.scene.allObjects[i];
+            if (window.GRAPHICS.scene.checkObject(o)) {
+                window.GRAPHICS.scene.showObject(i);
             }
         }
 
@@ -182,9 +182,9 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
                     SkyboxUriFront,
                 ]);
             }
-            GRAPHICS.scene.threeScene.background = this.skybox;
+            window.GRAPHICS.scene.threeScene.background = this.skybox;
         } else {
-            GRAPHICS.scene.threeScene.background = null;
+            window.GRAPHICS.scene.threeScene.background = null;
             this.skybox = null;
         }
 
@@ -209,9 +209,9 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
             }
             let far = this.renderDistance;
             let near = -1.0 + (far - (far * this.fogLevel));
-            GRAPHICS.scene.threeScene.fog = new THREE.Fog(color, near, far);
+            window.GRAPHICS.scene.threeScene.fog = new THREE.Fog(color, near, far);
         } else {
-            GRAPHICS.scene.threeScene.fog = null;
+            window.GRAPHICS.scene.threeScene.fog = null;
         }
     }
 
@@ -222,48 +222,48 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
     }
 
     setCameraMode() {
-        if (WORLDMANAGER !== undefined) {
-            if (this.hideRoofs === true) {
-                WORLDMANAGER.updatePlayerTile = this.noRoofCameraMode.bind(WORLDMANAGER);
-            } else {
-                WORLDMANAGER.updatePlayerTile = this.originalCameraMode.bind(WORLDMANAGER);
-            }
-            WORLDMANAGER.updatePlayerTile.call(WORLDMANAGER);
-        }
+        // if (WORLDMANAGER !== undefined) {
+        //     if (this.hideRoofs === true) {
+        //         WORLDMANAGER.updatePlayerTile = this.noRoofCameraMode.bind(WORLDMANAGER);
+        //     } else {
+        //         WORLDMANAGER.updatePlayerTile = this.originalCameraMode.bind(WORLDMANAGER);
+        //     }
+        //     WORLDMANAGER.updatePlayerTile.call(WORLDMANAGER);
+        // }
 
-        if (GRAPHICS !== undefined) {
+        if (window.GRAPHICS !== undefined) {
             if (this.unlockCamera === true) {
-                GRAPHICS.camera.controls.minDistance = this.minDistance;
-                GRAPHICS.camera.controls.maxDistance = this.maxDistance;
-                GRAPHICS.camera.controls.minPolarAngle = 0.35;
-                GRAPHICS.camera.controls.maxPolarAngle = 1.4;
+                window.GRAPHICS.camera.controls.minDistance = this.minDistance;
+                window.GRAPHICS.camera.controls.maxDistance = this.maxDistance;
+                window.GRAPHICS.camera.controls.minPolarAngle = 0.35;
+                window.GRAPHICS.camera.controls.maxPolarAngle = 1.4;
             } else {
-                GRAPHICS.camera.controls.minDistance = 8
-                GRAPHICS.camera.controls.maxDistance = 8;
-                GRAPHICS.camera.controls.minPolarAngle = THREE.Math.degToRad(45);
-                GRAPHICS.camera.controls.maxPolarAngle = THREE.Math.degToRad(57);
+                window.GRAPHICS.camera.controls.minDistance = 8
+                window.GRAPHICS.camera.controls.maxDistance = 8;
+                window.GRAPHICS.camera.controls.minPolarAngle = THREE.Math.degToRad(45);
+                window.GRAPHICS.camera.controls.maxPolarAngle = THREE.Math.degToRad(57);
             }
         }
     }
-    noRoofCameraMode() {
-        const self = (this as any);
+    // noRoofCameraMode() {
+    //     const self = (this as any);
 
-        let tile = self.loadedSegments[self.segmentKey].getTile(self.segment.lx, self.segment.ly)
-        if (!tile)
-            throw `Invalid location: ${self.segmentKey} ${self.segment.lx}, ${self.segment.ly}`
-        self.indoors = true;
-        for (let i in self.loadedSegments) {
-            self.loadedSegments[i].setIndoorStatus(self.indoors);
-        }
-        if (tile.pvp) {
-            let pvp = document.getElementById('pvp_indicator');
-            pvp.style.display = 'block';
-            pvp.innerText = "PvP Level: YES";
-            self.pvp_zone = true;
-        } else {
-            document.getElementById('pvp_indicator').style.display = 'none';
-            self.pvp_zone = false;
-        }
-        MUSIC_PLAYER.setNextTrack(tile.music);
-    }
+    //     let tile = self.loadedSegments[self.segmentKey].getTile(self.segment.lx, self.segment.ly)
+    //     if (!tile)
+    //         throw `Invalid location: ${self.segmentKey} ${self.segment.lx}, ${self.segment.ly}`
+    //     self.indoors = true;
+    //     for (let i in self.loadedSegments) {
+    //         self.loadedSegments[i].setIndoorStatus(self.indoors);
+    //     }
+    //     if (tile.pvp) {
+    //         let pvp = document.getElementById('pvp_indicator');
+    //         pvp.style.display = 'block';
+    //         pvp.innerText = "PvP Level: YES";
+    //         self.pvp_zone = true;
+    //     } else {
+    //         document.getElementById('pvp_indicator').style.display = 'none';
+    //         self.pvp_zone = false;
+    //     }
+    //     MUSIC_PLAYER.setNextTrack(tile.music);
+    // }
 }

--- a/src/plugins/genlite-camera.plugin.ts
+++ b/src/plugins/genlite-camera.plugin.ts
@@ -34,8 +34,8 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
 
     originalCameraMode: Function;
 
-    unlockCamera: boolean = false;
-    hideRoofs: boolean = false;
+    unlockCamera: boolean = true;
+    hideRoofs: boolean = true;
     maxDistance: Number = 15;
     minDistance: Number = Math.PI;
 
@@ -150,18 +150,18 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
 
     handleRenderDistance(value: number) {
         this.renderDistance = value;
-        window.GRAPHICS.camera.camera.far = value;
-        window.GRAPHICS.camera.camera.updateProjectionMatrix();
+        document.game.GRAPHICS.camera.camera.far = value;
+        document.game.GRAPHICS.camera.camera.updateProjectionMatrix();
 
         // genfanad does a bit of it's own object pruning, so we update that
         // distance as well Then we need to iterate over every object and
         // render the newly visible ones, because by default this would only
         // occur when the player moves.
-        window.GRAPHICS.scene.dd2 = value * value;
-        for (let i in window.GRAPHICS.scene.allObjects) {
-            let o = window.GRAPHICS.scene.allObjects[i];
-            if (window.GRAPHICS.scene.checkObject(o)) {
-                window.GRAPHICS.scene.showObject(i);
+        document.game.GRAPHICS.scene.dd2 = value * value;
+        for (let i in document.game.GRAPHICS.scene.allObjects) {
+            let o = document.game.GRAPHICS.scene.allObjects[i];
+            if (document.game.GRAPHICS.scene.checkObject(o)) {
+                document.game.GRAPHICS.scene.showObject(i);
             }
         }
 
@@ -172,7 +172,7 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
         this.skyboxEnabled = value;
         if (value) {
             if (this.skybox == null) {
-                const loader = new THREE.CubeTextureLoader();
+                const loader = new document.game.THREE.CubeTextureLoader();
                 this.skybox = loader.load([
                     SkyboxUriLeft,
                     SkyboxUriRight,
@@ -182,9 +182,9 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
                     SkyboxUriFront,
                 ]);
             }
-            window.GRAPHICS.scene.threeScene.background = this.skybox;
+            document.game.GRAPHICS.scene.threeScene.background = this.skybox;
         } else {
-            window.GRAPHICS.scene.threeScene.background = null;
+            document.game.GRAPHICS.scene.threeScene.background = null;
             this.skybox = null;
         }
 
@@ -209,9 +209,9 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
             }
             let far = this.renderDistance;
             let near = -1.0 + (far - (far * this.fogLevel));
-            window.GRAPHICS.scene.threeScene.fog = new THREE.Fog(color, near, far);
+            document.game.GRAPHICS.scene.threeScene.fog = new document.game.THREE.Fog(color, near, far);
         } else {
-            window.GRAPHICS.scene.threeScene.fog = null;
+            document.game.GRAPHICS.scene.threeScene.fog = null;
         }
     }
 
@@ -231,17 +231,17 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
         //     WORLDMANAGER.updatePlayerTile.call(WORLDMANAGER);
         // }
 
-        if (window.GRAPHICS !== undefined) {
+        if (document.game.GRAPHICS !== undefined) {
             if (this.unlockCamera === true) {
-                window.GRAPHICS.camera.controls.minDistance = this.minDistance;
-                window.GRAPHICS.camera.controls.maxDistance = this.maxDistance;
-                window.GRAPHICS.camera.controls.minPolarAngle = 0.35;
-                window.GRAPHICS.camera.controls.maxPolarAngle = 1.4;
+                document.game.GRAPHICS.camera.controls.minDistance = this.minDistance;
+                document.game.GRAPHICS.camera.controls.maxDistance = this.maxDistance;
+                document.game.GRAPHICS.camera.controls.minPolarAngle = 0.35;
+                document.game.GRAPHICS.camera.controls.maxPolarAngle = 1.4;
             } else {
-                window.GRAPHICS.camera.controls.minDistance = 8
-                window.GRAPHICS.camera.controls.maxDistance = 8;
-                window.GRAPHICS.camera.controls.minPolarAngle = THREE.Math.degToRad(45);
-                window.GRAPHICS.camera.controls.maxPolarAngle = THREE.Math.degToRad(57);
+                document.game.GRAPHICS.camera.controls.minDistance = 8
+                document.game.GRAPHICS.camera.controls.maxDistance = 8;
+                document.game.GRAPHICS.camera.controls.minPolarAngle = document.game.THREE.Math.degToRad(45);
+                document.game.GRAPHICS.camera.controls.maxPolarAngle = document.game.THREE.Math.degToRad(57);
             }
         }
     }

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -40,7 +40,7 @@ export class GenLiteChatPlugin implements GenLitePlugin {
     }
 
     public loginOK() {
-        this.originalGameMessage = CHAT.addGameMessage;
+        this.originalGameMessage = document.game.CHAT.addGameMessage;
         this.updateState();
     }
 
@@ -51,12 +51,12 @@ export class GenLiteChatPlugin implements GenLitePlugin {
 
     updateState() {
         if (this.filterGameMessages) {
-            CHAT.addGameMessage = this.newGameMessage.bind(
-                CHAT,
+            document.game.CHAT.addGameMessage = this.newGameMessage.bind(
+                document.game.CHAT,
                 this.originalGameMessage
             );
         } else {
-            CHAT.addGameMessage = this.originalGameMessage;
+            document.game.CHAT.addGameMessage = this.originalGameMessage;
         }
     }
 

--- a/src/plugins/genlite-inventory.plugin.ts
+++ b/src/plugins/genlite-inventory.plugin.ts
@@ -41,8 +41,8 @@ export class GenLiteInventoryPlugin implements GenLitePlugin {
 
     updateState() {
         if (this.disableDragOnShift) {
-            for (const i in INVENTORY.DOM_slots) {
-                let slot = INVENTORY.DOM_slots[i];
+            for (const i in document.game.INVENTORY.DOM_slots) {
+                let slot = document.game.INVENTORY.DOM_slots[i];
                 slot.item_div.onmousedown = function (e) {
                     if (e.shiftKey) {
                         e.preventDefault();
@@ -50,8 +50,8 @@ export class GenLiteInventoryPlugin implements GenLitePlugin {
                 }
             }
         } else {
-            for (const i in INVENTORY.DOM_slots) {
-                let slot = INVENTORY.DOM_slots[i];
+            for (const i in document.game.INVENTORY.DOM_slots) {
+                let slot = document.game.INVENTORY.DOM_slots[i];
                 slot.item_div.onmousedown = function (e) { };
             }
         }

--- a/src/plugins/genlite-item-highlight.plugin.ts
+++ b/src/plugins/genlite-item-highlight.plugin.ts
@@ -73,7 +73,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
 
     async init() {
         window.genlite.registerPlugin(this);
-        this.originalItemStackIntersects = ItemStack.prototype.intersects;
+        this.originalItemStackIntersects = document.game.ItemStack.intersects;
 
         this.loadItemList();
         this.createDiv();
@@ -110,7 +110,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
         window.addEventListener("blur", this.blurHandler.bind(this))
 
         if (this.isPluginEnabled === true) {
-            ItemStack.prototype.intersects = this.ItemStack_intersects;
+            document.game.ItemStack.intersects = this.ItemStack_intersects;
         }
     }
 
@@ -163,7 +163,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
 
     createElement(instanceId) {
         let stackable = false;
-        let itemStack = GAME.items[instanceId];
+        let itemStack = document.game.GAME.items[instanceId];
         let itemId = itemStack.item_keys[instanceId].item_id;
         let itemName = itemStack.item_info[itemId].name;
 
@@ -171,7 +171,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
             itemId = itemId.substring(7);
             stackable = true;
         } else {
-            stackable = DATA.items[itemId].stackable ?? false;
+            stackable = document.game.DATA.items[itemId].stackable ?? false;
         }
 
         let div = document.createElement('div');
@@ -251,9 +251,9 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
         // when disabling the plugin clear the current list of items
         if (state === false) {
             this.clearTracked();
-            ItemStack.prototype.intersects = this.originalItemStackIntersects;
+            document.game.ItemStack.intersects = this.originalItemStackIntersects;
         } else {
-            ItemStack.prototype.intersects = this.ItemStack_intersects;
+            document.game.ItemStack.intersects = this.ItemStack_intersects;
         }
 
         this.isPluginEnabled = state;
@@ -281,7 +281,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
     }
 
     getItemValue(itemId) {
-        let gameValue = DATA.items[itemId].value ?? 1;
+        let gameValue = document.game.DATA.items[itemId].value ?? 1;
         return gameValue;
     }
 
@@ -355,13 +355,13 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
         all_items.sort((a, b) => b.item.value - a.item.value);
 
         let show_examine_options = true;
-        if (all_items.length > ITEM_RIGHTCLICK_LIMIT / 2) show_examine_options = false;
+        if (all_items.length > window.game.ITEM_RIGHTCLICK_LIMIT / 2) show_examine_options = false;
 
         let options = 0;
         for (let entry of all_items) {
             let itemId = entry.id;
             let item = entry.item;
-            if (options > ITEM_RIGHTCLICK_LIMIT) break;
+            if (options > window.game.ITEM_RIGHTCLICK_LIMIT) break;
             options++;
             if (show_examine_options) {
                 list.push({
@@ -382,7 +382,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
                 text: all_keys.length > 1 ? 'Take one' : 'Take',
                 action: () => {
                     let take_id = all_keys[Math.floor(Math.random() * all_keys.length)];
-                    NETWORK.action('take', {
+                    window.game.NETWORK.action('take', {
                         item: take_id
                     })
                 }
@@ -402,7 +402,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
     }
 
     updateTrackedStacks() {
-        let itemStacks = GAME.items;
+        let itemStacks = document.game.GAME.items;
         let itemKeys = Object.keys(itemStacks);
         let keysToAdd = itemKeys.filter(k => !this.trackedStacks.includes(k));
         let keysToRemove = this.trackedStacks.filter(k => !itemKeys.includes(k));
@@ -426,7 +426,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
 
         for (let instanceId in this.itemElements) {
             let element = this.itemElements[instanceId];
-            let stack = GAME.items[element.instanceId];
+            let stack = document.game.GAME.items[element.instanceId];
             let itemId = element.itemId;
             if (stack !== undefined) {
                 if ((this.getItemData(itemId) == -1 || this.hideLables) && !this.isAltDown) {

--- a/src/plugins/genlite-item-highlight.plugin.ts
+++ b/src/plugins/genlite-item-highlight.plugin.ts
@@ -334,7 +334,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
 
     world_to_screen(pos, stack_count) {
         var p = pos;
-        var screenPos = p.project(GRAPHICS.threeCamera());
+        var screenPos = p.project(document.game.GRAPHICS.threeCamera());
         screenPos.x = (screenPos.x + 1) / 2 * window.innerWidth;
         screenPos.y = -(screenPos.y - 1) / 2 * window.innerHeight - (stack_count * 15);
         return screenPos;
@@ -370,7 +370,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
                     priority: - 1,
                     object: item,
                     text: 'Examine',
-                    action: () => CHAT.addGameMessage(item.examine)
+                    action: () => document.game.CHAT.addGameMessage(item.examine)
                 });
             }
             let all_keys = Object.keys(item.ids);
@@ -452,7 +452,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
                     stack_counter[posKey] = 0;
                 }
 
-                let worldPos = new THREE.Vector3().copy(stack.position());
+                let worldPos = new document.game.THREE.Vector3().copy(stack.position());
                 worldPos.y += 0.5;
                 let screenPos = this.world_to_screen(worldPos, stack_counter[posKey]);
                 if (screenPos.z > 1.0) {

--- a/src/plugins/genlite-menuswapper.plugin.ts
+++ b/src/plugins/genlite-menuswapper.plugin.ts
@@ -23,7 +23,7 @@ export class GenLiteMenuSwapperPlugin implements GenLitePlugin {
     originalSceneIntersects: Function;
     originalNPCIntersects: Function;
 
-    intersect_vector = new THREE.Vector3();
+    intersect_vector = new document.game.THREE.Vector3();
     async init() {
         window.genlite.registerPlugin(this);
 

--- a/src/plugins/genlite-music.plugin.ts
+++ b/src/plugins/genlite-music.plugin.ts
@@ -42,7 +42,7 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
 
     async init() {
         window.genlite.registerPlugin(this);
-        this.originalSetTrack = MUSIC_PLAYER.setNextTrack;
+        this.originalSetTrack = document.game.MUSIC_PLAYER.setNextTrack;
 
         this.isPluginEnabled = window.genlite.settings.add(
             "MusicPlugin.Enable",
@@ -126,7 +126,7 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
 
     updateMusicUI() {
         if (this.isPluginEnabled) {
-            MUSIC_PLAYER.setNextTrack = (t) => {
+            document.game.MUSIC_PLAYER.setNextTrack = (t) => {
                 if (this.musicMode == "passthrough") {
                     this.setNextTrack(t);
                 }
@@ -135,7 +135,7 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
                 this.toggleDisplay();
             };
         } else {
-            MUSIC_PLAYER.setNextTrack = this.originalSetTrack;
+            document.game.MUSIC_PLAYER.setNextTrack = this.originalSetTrack;
             SETTINGS.DOM_music_text.onclick = (e) => { };
             this.hideMusicSelection();
         }
@@ -199,7 +199,7 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
         }
 
         this.currentTrack = track;
-        this.originalSetTrack.call(MUSIC_PLAYER, track);
+        this.originalSetTrack.call(document.game.MUSIC_PLAYER, track);
     }
 
     toggleDisplay() {

--- a/src/plugins/genlite-npc-highlight.plugin.ts
+++ b/src/plugins/genlite-npc-highlight.plugin.ts
@@ -120,10 +120,10 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
                     mult by 0.8 which is the height of the health bar
                 */
                 if (key == this.curEnemy) {
-                    worldPos = new THREE.Vector3().copy(GAME.npcs[key].object.position());
+                    worldPos = new document.game.THREE.Vector3().copy(GAME.npcs[key].object.position());
                     worldPos.y += 0.8;
                 } else {
-                    worldPos = new THREE.Vector3().copy(GAME.npcs[key].position());
+                    worldPos = new document.game.THREE.Vector3().copy(GAME.npcs[key].position());
                     worldPos.y += GAME.npcs[key].height
                 }
                 let screenPos = this.world_to_screen(worldPos);
@@ -205,7 +205,7 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
 
     world_to_screen(pos) {
         var p = pos;
-        var screenPos = p.project(GRAPHICS.threeCamera());
+        var screenPos = p.project(document.game.GRAPHICS.threeCamera());
 
         screenPos.x = (screenPos.x + 1) / 2 * window.innerWidth;
         screenPos.y = -(screenPos.y - 1) / 2 * window.innerHeight;

--- a/src/plugins/genlite-npc-highlight.plugin.ts
+++ b/src/plugins/genlite-npc-highlight.plugin.ts
@@ -85,11 +85,11 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
             return;
         }
 
-        let npcsToAdd = Object.keys(GAME.npcs).filter(x => !Object.keys(this.trackedNpcs).includes(x));
-        let npcsToRemove = Object.keys(this.trackedNpcs).filter(x => !Object.keys(GAME.npcs).includes(x));
+        let npcsToAdd = Object.keys(document.game.GAME.npcs).filter(x => !Object.keys(this.trackedNpcs).includes(x));
+        let npcsToRemove = Object.keys(this.trackedNpcs).filter(x => !Object.keys(document.game.GAME.npcs).includes(x));
 
         for (let key in npcsToAdd) {
-            let npc = GAME.npcs[npcsToAdd[key]]
+            let npc = document.game.GAME.npcs[npcsToAdd[key]]
             let hpKey = this.packList[npc.id.split('-')[0]]
             let text = npc.htmlName;
             if (this.npcHealthList[hpKey] !== undefined)
@@ -108,7 +108,7 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
 
         for (let key in this.trackedNpcs) {
             let worldPos;
-            if (GAME.npcs[key] !== undefined) {
+            if (document.game.GAME.npcs[key] !== undefined) {
                 /* if the health was updated but the npc tag doesnt have that set regen the tag */
                 if (!this.trackedNpcs[key].hasHp && this.npcHealthList[this.packList[key.split('-')[0]]]) {
                     this.trackedNpcs[key].remove();
@@ -120,11 +120,11 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
                     mult by 0.8 which is the height of the health bar
                 */
                 if (key == this.curEnemy) {
-                    worldPos = new document.game.THREE.Vector3().copy(GAME.npcs[key].object.position());
+                    worldPos = new document.game.THREE.Vector3().copy(document.game.GAME.npcs[key].object.position());
                     worldPos.y += 0.8;
                 } else {
-                    worldPos = new document.game.THREE.Vector3().copy(GAME.npcs[key].position());
-                    worldPos.y += GAME.npcs[key].height
+                    worldPos = new document.game.THREE.Vector3().copy(document.game.GAME.npcs[key].position());
+                    worldPos.y += document.game.GAME.npcs[key].height
                 }
                 let screenPos = this.world_to_screen(worldPos);
                 if (key == this.curEnemy)
@@ -154,16 +154,16 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
 
     /* figure out which npc we are fighting and when that combat ends */
     handle(verb, payload) {
-        if (this.isPluginEnabled === false || NETWORK.loggedIn === false) {
+        if (this.isPluginEnabled === false || document.game.NETWORK.loggedIn === false) {
             return;
         }
 
         /* look for start of combat set the curEnemy and record data */
         if (verb == "spawnObject" && payload.type == "combat" &&
-            (payload.participant1 == PLAYER.id || payload.participant2 == PLAYER.id)) {
+            (payload.participant1 == document.game.PLAYER.id || payload.participant2 == document.game.PLAYER.id)) {
             this.curCombat = payload.id;
-            let curCombat = GAME.combats[payload.id];
-            this.curEnemy = curCombat.left.id == PLAYER.id ? curCombat.right.id : curCombat.left.id;
+            let curCombat = document.game.GAME.combats[payload.id];
+            this.curEnemy = curCombat.left.id == document.game.PLAYER.id ? curCombat.right.id : curCombat.left.id;
             return;
         }
         if (verb == "removeObject" && payload.type == "combat" && payload.id == this.curCombat) {
@@ -177,8 +177,8 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
         if (this.isPluginEnabled === false) {
             return;
         }
-        let object = GAME.objectById(update.id);
-        if (update.id == PLAYER.id || GAME.players[update.id] !== undefined || object === undefined)
+        let object = document.game.GAME.objectById(update.id);
+        if (update.id == document.game.PLAYER.id || document.game.GAME.players[update.id] !== undefined || object === undefined)
             return;
 
         let hpKey = this.packList[object.id.split('-')[0]];
@@ -190,7 +190,7 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
             this.npcHealthList[hpKey] = update.maxhp;
             localStorage.setItem("GenliteNPCHealthList", JSON.stringify(this.npcHealthList));
         }
-        npcsToMod = Object.keys(GAME.npcs).filter(x => GAME.npcs[x].id.split('-')[0] == object.id.split('-')[0]);
+        npcsToMod = Object.keys(document.game.GAME.npcs).filter(x => document.game.GAME.npcs[x].id.split('-')[0] == object.id.split('-')[0]);
         for (let key in npcsToMod) {
             let npcid = npcsToMod[key];
             if (this.trackedNpcs[npcid] && this.trackedNpcs[npcid].hasHp)

--- a/src/plugins/genlite-playertools.plugin.ts
+++ b/src/plugins/genlite-playertools.plugin.ts
@@ -133,10 +133,10 @@ export class GenLitePlayerToolsPlugin implements GenLitePlugin {
             // If the Player is in combat, then use the Player's Object Position
             // If the Player is not in combat, then use the Player's Position
             
-            let playerPosition = new THREE.Vector3().copy(character.position()); // Vector3
+            let playerPosition = new document.game.THREE.Vector3().copy(character.position()); // Vector3
 
             if (Object.keys(GAME.combats).some(cID => GAME.combats[cID].left.id == pID || GAME.combats[cID].right.id == pID)) {
-                playerPosition = new THREE.Vector3().copy(character.object.position()); // We are in combat, use the Player's Object Position
+                playerPosition = new document.game.THREE.Vector3().copy(character.object.position()); // We are in combat, use the Player's Object Position
             }
 
             // Offset the Player's Position by the Player's Height (This allows the Player Tag to be above the Player's Head)
@@ -182,13 +182,13 @@ export class GenLitePlayerToolsPlugin implements GenLitePlugin {
     }
 
     handleHidePlayerSettingChange(state: boolean) {
-        GRAPHICS.threeScene.getObjectByName(GAME.me.id).visible = !state;
+        document.game.GRAPHICS.threeScene.getObjectByName(GAME.me.id).visible = !state;
     }
 
 
     world_to_screen(pos) {
         var p = pos;
-        var screenPos = p.project(GRAPHICS.threeCamera());
+        var screenPos = p.project(document.game.GRAPHICS.threeCamera());
 
         screenPos.x = (screenPos.x + 1) / 2 * window.innerWidth;
         screenPos.y = -(screenPos.y - 1) / 2 * window.innerHeight;

--- a/src/plugins/genlite-recipe-recorder.plugin.ts
+++ b/src/plugins/genlite-recipe-recorder.plugin.ts
@@ -165,7 +165,7 @@ export class GenLiteRecipeRecorderPlugin implements GenLitePlugin {
             if (this.gatherResults[this.gatherTask] === undefined)
                 this.gatherResults[this.gatherTask] = {};
             let gather = this.gatherResults[this.gatherTask];
-            let nodeKey = GRAPHICS.scene.allObjects[this.gatherNode].modelInfo.nick;
+            let nodeKey = document.game.GRAPHICS.scene.allObjects[this.gatherNode].modelInfo.nick;
             if (gather[nodeKey] === undefined)
                 gather[nodeKey] = {};
             let node = gather[nodeKey];
@@ -209,7 +209,7 @@ export class GenLiteRecipeRecorderPlugin implements GenLitePlugin {
         if (this.gatherResults[this.gatherTask] === undefined)
             this.gatherResults[this.gatherTask] = {};
         let gather = this.gatherResults[this.gatherTask];
-        let nodeKey = GRAPHICS.scene.allObjects[this.gatherNode].modelInfo.impl.params;
+        let nodeKey = document.game.GRAPHICS.scene.allObjects[this.gatherNode].modelInfo.impl.params;
         if (gather[nodeKey] === undefined)
             gather[nodeKey] = {};
         let node = gather[nodeKey];

--- a/src/plugins/genlite-sound-notification.plugin.ts
+++ b/src/plugins/genlite-sound-notification.plugin.ts
@@ -55,7 +55,7 @@ export class GenLiteSoundNotification implements GenLitePlugin {
         /* create a new SFXPlayer we will swap to this if overriding 
         this is so the games normal effects play at their correct volume
         */
-        this.genliteSoundListener = new THREE.AudioListener();
+        this.genliteSoundListener = new document.game.THREE.AudioListener();
         this.genliteSoundListener.setMasterVolume(this.overrideVolume / 100.0) //bypas setvolume so you dont have to override it 
         this.genliteSFXPlayer = new SFXPlayer();
         this.genliteSFXPlayer.load();
@@ -125,7 +125,7 @@ export class GenLiteSoundNotification implements GenLitePlugin {
 
     /* play override, currently absolutely no safety features but we shouldnt need any */
     overridePlay(key, volume = 1) {
-        let sound = new THREE.Audio(this.genliteSoundListener);
+        let sound = new document.game.THREE.Audio(this.genliteSoundListener);
         sound.setLoop(false);
         sound.setBuffer(this.genliteSFXPlayer.sounds[key]);
         sound.setVolume(volume);

--- a/src/plugins/genlite-wiki-data-collection.plugin.ts
+++ b/src/plugins/genlite-wiki-data-collection.plugin.ts
@@ -76,14 +76,18 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
         if (!this.isRemoteEnabled) {
             return;
         }
-        this.playerMeleeCL = Math.trunc((PLAYER_INFO.skills.attack.level + PLAYER_INFO.skills.defense.level + PLAYER_INFO.skills.strength.level) / 3);
-        this.playerRangedCL = PLAYER_INFO.skills.ranged.level;
+        this.playerMeleeCL = Math.trunc((
+            document.game.PLAYER_INFO.skills.attack.level +
+            document.game.PLAYER_INFO.skills.defense.level +
+            document.game.PLAYER_INFO.skills.strength.level
+        ) / 3);
+        this.playerRangedCL = document.game.PLAYER_INFO.skills.ranged.level;
     }
 
     combatUpdate(update) {
-        let object = GAME.objectById(update.id);
+        let object = document.game.GAME.objectById(update.id);
 
-        if (update.id == PLAYER.id || GAME.players[update.id] !== undefined)
+        if (update.id == document.game.PLAYER.id || document.game.GAME.players[update.id] !== undefined)
             return;
 
         if (!object || !object.object)
@@ -104,9 +108,9 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
 
         /* look for start of combat set the curEnemy and record data */
         if (verb == "spawnObject" && payload.type == "combat" &&
-            (payload.participant1 == PLAYER.id || payload.participant2 == PLAYER.id)) {
-            this.curCombat = GAME.combats[payload.id];
-            if (this.curCombat.left.id != PLAYER.id) {
+            (payload.participant1 == document.game.PLAYER.id || payload.participant2 == document.game.PLAYER.id)) {
+            this.curCombat = document.game.GAME.combats[payload.id];
+            if (this.curCombat.left.id != document.game.PLAYER.id) {
                 this.curEnemy = this.curCombat.left;
             } else {
                 this.curEnemy = this.curCombat.right;
@@ -114,8 +118,8 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
         }
 
         /* if ranging look for projectiles */
-        if (verb == "projectile" && payload.source == PLAYER.id) {
-            this.curEnemy = GAME.npcs[payload.target];
+        if (verb == "projectile" && payload.source == document.game.PLAYER.id) {
+            this.curEnemy = document.game.GAME.npcs[payload.target];
         }
 
         if (verb == "combatUI") {
@@ -138,8 +142,8 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
 
     updateXP(xp) {
         if (xp.levelUp) {
-            this.playerMeleeCL = Math.trunc((PLAYER_INFO.skills.attack.level + PLAYER_INFO.skills.defense.level + PLAYER_INFO.skills.strength.level) / 3);
-            this.playerRangedCL = PLAYER_INFO.skills.ranged.level;
+            this.playerMeleeCL = Math.trunc((document.game.PLAYER_INFO.skills.attack.level + document.game.PLAYER_INFO.skills.defense.level + document.game.PLAYER_INFO.skills.strength.level) / 3);
+            this.playerRangedCL = document.game.PLAYER_INFO.skills.ranged.level;
         }
         if (this.curEnemy === undefined)
             return;
@@ -174,13 +178,13 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
         let npcs = {}
         let blackList = [];
         /* do some aggregrate stuff packSize, and add up mapsegment for averaging later */
-        for (let key in GAME.npcs) {
-            let npc = GAME.npcs[key];
+        for (let key in document.game.GAME.npcs) {
+            let npc = document.game.GAME.npcs[key];
             let npcX = npc.pos2.x;
             let npcY = npc.pos2.y;
             let packId = key.split('-')[0];
             /* if any member of the pack is above 30 tiles away ignore it because there might be more memeber out of range */
-            if (Math.abs(npcX - PLAYER.character.pos2.x) > 30 || Math.abs(npcY - PLAYER.character.pos2.y) > 30 || blackList.includes(packId)) {
+            if (Math.abs(npcX - document.game.PLAYER.character.pos2.x) > 30 || Math.abs(npcY - document.game.PLAYER.character.pos2.y) > 30 || blackList.includes(packId)) {
                 delete npcs[packId]
                 blackList.push(packId)
                 continue;
@@ -200,10 +204,10 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
             let group = 'A';
             let npc = npcs[packId].npc;
             /* calculate the mob key and increment the group if the key conflicts with a prexisting entry */
-            let mobKey = `${npc.info.name}-${npc.info.level ? npc.info.level : 0}--${npcInfo.packSize}--${PLAYER.location.layer}:${mapSegX}:${mapSegY}-${group}`;
+            let mobKey = `${npc.info.name}-${npc.info.level ? npc.info.level : 0}--${npcInfo.packSize}--${document.game.PLAYER.location.layer}:${mapSegX}:${mapSegY}-${group}`;
             while (this.previously_seen[mobKey] !== undefined && this.previously_seen[mobKey].ign_mobkey != packId) {
                 group = String.fromCharCode(group.charCodeAt(0) + 1);
-                mobKey = `${npc.info.name}-${npc.info.level ? npc.info.level : 0}--${npcInfo.packSize}--${PLAYER.location.layer}:${mapSegX}:${mapSegY}-${group}`;
+                mobKey = `${npc.info.name}-${npc.info.level ? npc.info.level : 0}--${npcInfo.packSize}--${document.game.PLAYER.location.layer}:${mapSegX}:${mapSegY}-${group}`;
             }
 
             if (this.previously_seen[mobKey] !== undefined) {
@@ -219,7 +223,7 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
                 "Monster_Pack_ID": mobKey,
                 "X": npcInfo.mapSegX / npcInfo.packSize,
                 "Y": npcInfo.mapSegY / npcInfo.packSize,
-                "Layer": PLAYER.location.layer,
+                "Layer": document.game.PLAYER.location.layer,
                 "Pack_Size": npcInfo.packSize,
                 "Monster_HP": 0,
                 "Base_Xp": 0,

--- a/src/plugins/genlite-xp-calculator.plugin.ts
+++ b/src/plugins/genlite-xp-calculator.plugin.ts
@@ -109,11 +109,11 @@ export class GenLiteXpCalculator implements GenLitePlugin {
             if (element == "total")
                 skill.gainedXP += xp.xp;
             if (element != "total")
-                skill.actionsToNext = Math.ceil(PLAYER_INFO.skills[element].tnl / skill.avgActionXP);
+                skill.actionsToNext = Math.ceil(document.game.PLAYER_INFO.skills[element].tnl / skill.avgActionXP);
             if (skill.tsStart == 0) {
                 skill.tsStart = Date.now();
                 if (element != "total")
-                    skill.startXP = PLAYER_INFO.skills[element].xp - xp.xp;
+                    skill.startXP = document.game.PLAYER_INFO.skills[element].xp - xp.xp;
             }
         });
     }
@@ -123,10 +123,10 @@ export class GenLiteXpCalculator implements GenLitePlugin {
         if (!callback_this.isPluginEnabled) {
             return;
         }
-        callback_this.tracking_skill = PLAYER_INFO.tracking_skill.id;
+        callback_this.tracking_skill = document.game.PLAYER_INFO.tracking_skill.id;
         let div = <HTMLElement>document.getElementById("skill_status_popup");
-        let piSkill = PLAYER_INFO.skills[PLAYER_INFO.tracking_skill.id];
-        let skill = callback_this.skillsList[PLAYER_INFO.tracking_skill.id];
+        let piSkill = document.game.PLAYER_INFO.skills[document.game.PLAYER_INFO.tracking_skill.id];
+        let skill = callback_this.skillsList[document.game.PLAYER_INFO.tracking_skill.id];
         let xpRate = 0;
         let timeDiff = Date.now() - skill.tsStart;
         if (skill.tsStart != 0) {
@@ -161,9 +161,9 @@ export class GenLiteXpCalculator implements GenLitePlugin {
         if (!this.isPluginEnabled) {
             return;
         }
-        if (PLAYER_INFO.tracking && this.tracking_skill != "total") {
+        if (document.game.PLAYER_INFO.tracking && this.tracking_skill != "total") {
             this.onmouseenter(null, this);
-        } else if (PLAYER_INFO.tracking && this.tracking_skill == "total") {
+        } else if (document.game.PLAYER_INFO.tracking && this.tracking_skill == "total") {
             this.totalLevelCalc(null, this);
         }
     }
@@ -178,7 +178,7 @@ export class GenLiteXpCalculator implements GenLitePlugin {
         for (let i in this.skillsList) {
             if (i == "total")
                 continue;
-            this.skillsList.total.startXP += PLAYER_INFO.skills[i].xp;
+            this.skillsList.total.startXP += document.game.PLAYER_INFO.skills[i].xp;
         }
     }
 
@@ -197,7 +197,7 @@ export class GenLiteXpCalculator implements GenLitePlugin {
     totalLevelCalc(event, callback_this) {
         if (!callback_this.isPluginEnabled)
             return;
-        PLAYER_INFO.tracking = true;
+        document.game.PLAYER_INFO.tracking = true;
         callback_this.tracking_skill = "total"
         let total = callback_this.skillsList.total;
         let div = document.getElementById("skill_status_popup");
@@ -243,7 +243,7 @@ export class GenLiteXpCalculator implements GenLitePlugin {
         delete temp.gainedXP;
         this.skillsList[skill] = temp;
         if (this.isHookInstalled)
-            PLAYER_INFO.updateTooltip();
+            document.game.PLAYER_INFO.updateTooltip();
     }
 
     resetCalculatorAll(event = null) {

--- a/userscript-banner.txt
+++ b/userscript-banner.txt
@@ -6,7 +6,9 @@
 // @author       https://github.com/Retoxified/GenLite/blob/main/CREDITS.md
 // @match        https://play.genfanad.com/play/
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=genfanad.com
-// @grant        none
+// @resource     clientjs   https://play.genfanad.com/play/js/client.js
+// @grant        GM_getResourceText
+// @run-at       document-start
 // ==/UserScript==
 
 /*


### PR DESCRIPTION
A bunch of changes here to make GenLite work the the recent update using webpack.

### Accessing Client Code
First, we need to hook into the Genfanad IIFE. To do this we use GM_getResourceText to grab the script and inject a getter/setter into it's context and expose it via document.client.

Then we use a MutationObserver to wait for the client.js script object, and replace it with our modified script. Note that this does not work on Firefox, because the script is fetched before we can remove it's src. Instead we use beforescriptexecute which is a Firefox only API.

### Mapping Minified Code
Once we have this, initGenLite will map some previously global objects with now-minified names into a document.game. These are objects such as NETWORK, and ItemStack.

The only changes needed for actual plugin code is to prefix these globals with the new namespace.

### Enabled Plugins
Not all plugins work, since not all game objects have been mapped into document.game (and plugins are not updated).

Currently these plugins are enabled and working:
- Camera
- NPCHighlight
- ItemHighlight
- WikiDataCollection
- XpCalculator