### PR TITLE
update readme + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 GenLite installation instructions
 1. Install [TamperMonkey(All Browsers)](https://www.tampermonkey.net/) in your browser of choice.
-2. Click [here](https://github.com/Retoxified/GenLite/raw/release/dist/genlite.user.js) to install GenLite
-3. Enjoy! GenLite should automatically update whenever there is a new version. We will announce new versions in our discord server.
+2. Change Tampermonkey Inject Mode
+    1. Go to Tampermonkey -> Dashboard -> Settings tab
+    2. At the top, change Config Mode to "Advanced"
+    3. At the bottom under Experimental, change Inject Mode to "Instant"
+3. Click [here](https://github.com/Retoxified/GenLite/raw/release/dist/genlite.user.js) to install GenLite
+4. Enjoy! GenLite should automatically update whenever there is a new version. We will announce new versions in our discord server.
 
 Join us on Discord: https://discord.gg/Jn7s7pArdg
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GenLite 0.1.39 - For GenFanad
+# GenLite 0.1.40 - For GenFanad
 
 GenLite installation instructions
 1. Install [TamperMonkey(All Browsers)](https://www.tampermonkey.net/) in your browser of choice.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GenLite",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "scripts": {
     "build:prod": "npm version patch --no-git-tag-version --force && npx webpack --mode production",
     "build:dev": "npx webpack --mode development",

--- a/src/core/genlite-plugin-loader.class.ts
+++ b/src/core/genlite-plugin-loader.class.ts
@@ -24,7 +24,7 @@ export class GenLitePluginLoader {
     /**
      * Instantiates an instance of pluginClass,
      * Runs its async init() function
-     * Adds a window field for the instance matching pluginClass.name
+     * Adds a document field for the instance matching pluginClass.name
      * The plugin instance will then also appear in this.plugins[]
      * @param pluginClass
      * @returns {Promise<boolean>}
@@ -42,7 +42,7 @@ export class GenLitePluginLoader {
             const pluginInstance = new pluginClass();
             await pluginInstance.init();
 
-            window[pluginClass.pluginName] = pluginInstance;
+            document[pluginClass.pluginName] = pluginInstance;
 
             this.plugins.push(pluginInstance);
             console.log(`[GenLitePluginLoader]: Loaded plugin ${pluginClass.pluginName}`);

--- a/src/core/plugins/genlite-commands.plugin.ts
+++ b/src/core/plugins/genlite-commands.plugin.ts
@@ -6,14 +6,14 @@ export class GenLiteCommandsPlugin {
     private originalProcessInput: Function;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
         this.originalProcessInput = document.game.Chat.processInput;
         this.register("help", function (s) {
             if (!s) {
-                let helpStr = Object.keys(window.genlite.commands.commands).join(", ");
-                window.genlite.commands.print("GenLite Commands");
-                window.genlite.commands.print(helpStr);
+                let helpStr = Object.keys(document.genlite.commands.commands).join(", ");
+                document.genlite.commands.print("GenLite Commands");
+                document.genlite.commands.print(helpStr);
                 return;
             }
 
@@ -25,20 +25,20 @@ export class GenLiteCommandsPlugin {
             let command = s.slice(0, end);
             let args = s.slice(end + 1);
 
-            if (command in window.genlite.commands.commands) {
-                let spec = window.genlite.commands.commands[command];
+            if (command in document.genlite.commands.commands) {
+                let spec = document.genlite.commands.commands[command];
                 if (spec.helpFunction) {
                     var text = spec.helpFunction(args);
                     if (text != null && text != "") {
-                        window.genlite.commands.print(text);
+                        document.genlite.commands.print(text);
                     }
                 } else if (spec.helpText) {
-                    window.genlite.commands.print(spec.helpText);
+                    document.genlite.commands.print(spec.helpText);
                 } else {
-                    window.genlite.commands.print("no help defined for this command");
+                    document.genlite.commands.print("no help defined for this command");
                 }
             } else {
-                window.genlite.commands.print("no such command");
+                document.genlite.commands.print("no such command");
             }
         }, "display help text for a command: '//help <command>'");
     }
@@ -82,7 +82,7 @@ export class GenLiteCommandsPlugin {
             }
             spec.handler(args);
         } else {
-            let helpStr = Object.keys(window.genlite.commands.commands).join(" ");
+            let helpStr = Object.keys(document.genlite.commands.commands).join(" ");
             this.print("invalid command\"" + command + "\". Options: " + helpStr);
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,6 @@ let isInitialized = false;
 
         const genlite = new GenLite();
         document.genlite = genlite;
-        window.genlite = genlite;
         await genlite.init();
 
         /** Core Features */
@@ -156,9 +155,9 @@ let isInitialized = false;
         // await genlite.pluginLoader.addPlugin(GenLiteHighscores);
 
         /** post init things */
-        await window.GenLiteSettingsPlugin.postInit();
-        await window.GenLiteNPCHighlightPlugin.postInit();
-        // await window.GenLiteDropRecorderPlugin.postInit();
+        await document['GenLiteSettingsPlugin'].postInit();
+        await document['GenLiteNPCHighlightPlugin'].postInit();
+        // await document['GenLiteDropRecorderPlugin'].postInit();
 
         // NOTE: currently initGenlite is called after the scene has started
         //       (in minified function NS). The initializeUI function does not

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ declare global {
     interface Document {
         game: any;
         client: any;
+        genlite: any;
         initGenLite: () => void;
     }
 }
@@ -81,10 +82,6 @@ let isInitialized = false;
     localStorage.setItem("GenLiteConfirms", confirmed);
 
     async function initGenLite() {
-        if (isInitialized) {
-            return;
-        }
-        isInitialized = true;
 
         function gameObject(name: string, minified: string): any {
             var o = document.client.get(minified);
@@ -120,7 +117,14 @@ let isInitialized = false;
         gameObject('WorldManager', 'bS');
         gameObject('ITEM_RIGHTCLICK_LIMIT', 'Os');
 
+        if (isInitialized) {
+            document.genlite.onUIInitialized();
+            return;
+        }
+        isInitialized = true;
+
         const genlite = new GenLite();
+        document.genlite = genlite;
         window.genlite = genlite;
         await genlite.init();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,8 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
     + "};"
     + scriptText.substring(scriptText.length-5);
 
+let isInitialized = false;
+
 (async function load() {
     let confirmed = localStorage.getItem("GenLiteConfirms");
     if (!confirmed && await GenLiteConfirmation.confirm(DISCLAIMER) === true)
@@ -79,6 +81,10 @@ scriptText = scriptText.substring(0, scriptText.length - 5)
     localStorage.setItem("GenLiteConfirms", confirmed);
 
     async function initGenLite() {
+        if (isInitialized) {
+            return;
+        }
+        isInitialized = true;
 
         function gameObject(name: string, minified: string): any {
             var o = document.client.get(minified);

--- a/src/plugins/genlite-camera.plugin.ts
+++ b/src/plugins/genlite-camera.plugin.ts
@@ -46,13 +46,13 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
     skybox: any = null;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
         this.originalCameraMode = document.game.WorldManager.updatePlayerTile;
 
-        this.unlockCamera = window.genlite.settings.add("Camera.UnlockCam", true, "Unlock Camera", "checkbox", this.handleUnlockCameraToggle, this);
-        this.hideRoofs = window.genlite.settings.add("Camera.HideRoofs", true, "Hide Roofs", "checkbox", this.handleHideRoofToggle, this);
-        this.maxDistance = parseInt(window.genlite.settings.add(
+        this.unlockCamera = document.genlite.settings.add("Camera.UnlockCam", true, "Unlock Camera", "checkbox", this.handleUnlockCameraToggle, this);
+        this.hideRoofs = document.genlite.settings.add("Camera.HideRoofs", true, "Hide Roofs", "checkbox", this.handleHideRoofToggle, this);
+        this.maxDistance = parseInt(document.genlite.settings.add(
             "Camera.maxDistance",
             "15",
             "Max Distance: <div style=\"display: contents;\" id=\"GenLiteMaxDistanceOutput\"></div>",
@@ -69,7 +69,7 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
             ], "Camera.UnlockCam"
         ));
         document.getElementById("GenLiteMaxDistanceOutput").innerHTML = this.maxDistance.toString();
-        this.minDistance = parseInt(window.genlite.settings.add(
+        this.minDistance = parseInt(document.genlite.settings.add(
             "Camera.minDistance",
             "3.14",
             "Min Distance: <div style=\"display: contents;\" id=\"GenLiteMinDistanceOutput\"></div>",
@@ -86,9 +86,9 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
             ], "Camera.UnlockCam"
         ));
         document.getElementById("GenLiteMinDistanceOutput").innerHTML = this.minDistance.toString();
-        this.skyboxEnabled = window.genlite.settings.add("Camera.Skybox", true, "Skybox", "checkbox", this.handleSkybox, this);
-        this.distanceFog = window.genlite.settings.add("Camera.Fog", true, "Fog", "checkbox", this.handleFog, this);
-        this.fogLevel = parseFloat(window.genlite.settings.add(
+        this.skyboxEnabled = document.genlite.settings.add("Camera.Skybox", true, "Skybox", "checkbox", this.handleSkybox, this);
+        this.distanceFog = document.genlite.settings.add("Camera.Fog", true, "Fog", "checkbox", this.handleFog, this);
+        this.fogLevel = parseFloat(document.genlite.settings.add(
             "Camera.FogLevel",
             GenLiteCameraPlugin.defaultFogLevel.toString(),
             "Fog Level",
@@ -107,7 +107,7 @@ export class GenLiteCameraPlugin implements GenLitePlugin {
             ],
             this.distanceFog
         ));
-        this.renderDistance = parseFloat(window.genlite.settings.add(
+        this.renderDistance = parseFloat(document.genlite.settings.add(
             "Camera.RenderDistance",
             GenLiteCameraPlugin.defaultRenderDistance.toString(),
             "Render Distance",

--- a/src/plugins/genlite-chat.plugin.ts
+++ b/src/plugins/genlite-chat.plugin.ts
@@ -28,8 +28,8 @@ export class GenLiteChatPlugin implements GenLitePlugin {
     originalGameMessage: Function;
 
     async init() {
-        window.genlite.registerPlugin(this);
-        this.filterGameMessages = window.genlite.settings.add(
+        document.genlite.registerPlugin(this);
+        this.filterGameMessages = document.genlite.settings.add(
             "Chat.FilterGameMessages",
             false,
             "Filter Game Chat",

--- a/src/plugins/genlite-drop-recorder.plugin.ts
+++ b/src/plugins/genlite-drop-recorder.plugin.ts
@@ -45,15 +45,15 @@ export class GenLiteDropRecorderPlugin implements GenLitePlugin {
     submitItemsToServer: boolean = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
         let dropTableString = localStorage.getItem("genliteDropTable");
         if (dropTableString == null) {
             this.dropTable = {};
         } else {
             this.dropTable = JSON.parse(dropTableString);
         }
-        this.isPluginEnabled = window.genlite.settings.add("DropRecorder.Enable", true, "Drop Recorder", "checkbox", this.handlePluginEnableDisable, this);
-        this.submitItemsToServer = window.genlite.settings.add(
+        this.isPluginEnabled = document.genlite.settings.add("DropRecorder.Enable", true, "Drop Recorder", "checkbox", this.handlePluginEnableDisable, this);
+        this.submitItemsToServer = document.genlite.settings.add(
             "DropRecorder.SubmitToServer", // Key
             false,                         // Default
             "Send Drops to Server(REMOTE SERVER)", // Name in UI
@@ -69,7 +69,7 @@ export class GenLiteDropRecorderPlugin implements GenLitePlugin {
     }
 
     async postInit() {
-        this.packList = window.GenLiteWikiDataCollectionPlugin.packList;
+        this.packList = document['GenLiteWikiDataCollectionPlugin'].packList;
     }
 
     handlePluginEnableDisable(state: boolean) {
@@ -151,7 +151,7 @@ export class GenLiteDropRecorderPlugin implements GenLitePlugin {
             this.objectSpawns = [];
             this.enemyDead = Number.POSITIVE_INFINITY;
             if (this.submitItemsToServer === true)
-                window.genlite.sendDataToServer("droplogproject", this.monsterData);
+                document.genlite.sendDataToServer("droplogproject", this.monsterData);
 
             this.localDropRecording();
             return;

--- a/src/plugins/genlite-generalchatcommand.plugin.ts
+++ b/src/plugins/genlite-generalchatcommand.plugin.ts
@@ -24,7 +24,7 @@ export class GenLiteGeneralChatCommands implements GenLitePlugin {
     isLogged = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
         let playedString = localStorage.getItem("genlitePlayed")
         if (playedString == null) {
@@ -32,8 +32,8 @@ export class GenLiteGeneralChatCommands implements GenLitePlugin {
         } else {
             this.playedTime = parseInt(playedString);
         }
-        window.genlite.commands.register("played", () => { this.printPlayedTime.apply(this) }, "Prints time played.");
-        window.genlite.commands.register("logged", () => { this.printLoggedTime.apply(this) }, "Prints time logged in.");
+        document.genlite.commands.register("played", () => { this.printPlayedTime.apply(this) }, "Prints time played.");
+        document.genlite.commands.register("logged", () => { this.printLoggedTime.apply(this) }, "Prints time logged in.");
     }
 
     loginOK() {
@@ -57,11 +57,11 @@ export class GenLiteGeneralChatCommands implements GenLitePlugin {
 
     /* genlite command callbacks */
     printLoggedTime() {
-        window.genlite.commands.print(this.msToHumanTime(Date.now() - this.loginTime));
+        document.genlite.commands.print(this.msToHumanTime(Date.now() - this.loginTime));
     }
 
     printPlayedTime() {
-        window.genlite.commands.print(this.msToHumanTime(this.playedTime));
+        document.genlite.commands.print(this.msToHumanTime(this.playedTime));
     }
 
     savePlayed() {

--- a/src/plugins/genlite-highscores.plugin.ts
+++ b/src/plugins/genlite-highscores.plugin.ts
@@ -74,8 +74,8 @@ export class GenLiteHighscores implements GenLitePlugin {
         total: true
     }
     async init() {
-        window.genlite.registerPlugin(this);
-        this.submitItemsToServer = window.genlite.settings.add(
+        document.genlite.registerPlugin(this);
+        this.submitItemsToServer = document.genlite.settings.add(
             "Highscores.SubmitToServer", // Key
             false,                         // Default
             "Send Highscores to Server(REMOTE SERVER)", // Name in UI
@@ -86,9 +86,9 @@ export class GenLiteHighscores implements GenLitePlugin {
             "Turning this setting on will send highscore data along with your IP\u00A0address to an external server.\n\n" +
             "Are you sure you want to enable this setting?"
         );
-        this.sendAll = window.genlite.settings.add(`Highscore.ToggleButton`, false, `Toggle All Settings`, "checkbox", this.toggleAll, this, undefined, undefined, "Highscores.SubmitToServer");
+        this.sendAll = document.genlite.settings.add(`Highscore.ToggleButton`, false, `Toggle All Settings`, "checkbox", this.toggleAll, this, undefined, undefined, "Highscores.SubmitToServer");
         for (let key in this.statsToSend)
-            this.statsToSend[key] = window.genlite.settings.add(`Highscore.${key}.Enable`, false, `Highscore: ${key}`, "checkbox", (state) => { this.statsToSend[key] = state }, this, undefined, undefined, "Highscores.SubmitToServer");
+            this.statsToSend[key] = document.genlite.settings.add(`Highscore.${key}.Enable`, false, `Highscore: ${key}`, "checkbox", (state) => { this.statsToSend[key] = state }, this, undefined, undefined, "Highscores.SubmitToServer");
 
         let walkStr = localStorage.getItem("Highscores.walkData")
         if (walkStr != null)
@@ -110,7 +110,7 @@ export class GenLiteHighscores implements GenLitePlugin {
     toggleAll(state) {
         this.sendAll = state;
         for (let key in this.statsToSend)
-            window.genlite.settings.toggle(`Highscore.${key}.Enable`, state);
+            document.genlite.settings.toggle(`Highscore.${key}.Enable`, state);
     }
 
     /* interval setup */
@@ -207,13 +207,13 @@ export class GenLiteHighscores implements GenLitePlugin {
         }
 
         if (this.statsToSend.Played) {
-            if (window.GenLiteGeneralChatCommands.playedTime > 31556926000) {
-                window.GenLiteGeneralChatCommands.playedTime = 0;
+            if (document['GenLiteGeneralChatCommands'].playedTime > 31556926000) {
+                document['GenLiteGeneralChatCommands'].playedTime = 0;
             } else {
                 this.highscores.Stats.push(
                     {
                         Stat: "Played Time",
-                        Data1: window.GenLiteGeneralChatCommands.playedTime
+                        Data1: document['GenLiteGeneralChatCommands'].playedTime
                     });
             }
         }
@@ -232,6 +232,6 @@ export class GenLiteHighscores implements GenLitePlugin {
     }
     sendToServer() {
         this.updateScores();
-        window.genlite.sendDataToServer("playerstats", this.highscores);
+        document.genlite.sendDataToServer("playerstats", this.highscores);
     }
 }

--- a/src/plugins/genlite-hit-recorder.plugin.ts
+++ b/src/plugins/genlite-hit-recorder.plugin.ts
@@ -86,8 +86,8 @@ export class GenLiteHitRecorder implements GenLitePlugin {
     }
 
     async init() {
-        window.genlite.registerPlugin(this);
-        this.isPluginEnabled = window.genlite.settings.add("HitRecorder.Enable", true, "Hit Recorder", "checkbox", this.handlePluginEnableDisable, this);
+        document.genlite.registerPlugin(this);
+        this.isPluginEnabled = document.genlite.settings.add("HitRecorder.Enable", true, "Hit Recorder", "checkbox", this.handlePluginEnableDisable, this);
         this.dpsOverlayContainer.appendChild(this.dpsOverlay);
     }
 

--- a/src/plugins/genlite-inventory.plugin.ts
+++ b/src/plugins/genlite-inventory.plugin.ts
@@ -19,8 +19,8 @@ export class GenLiteInventoryPlugin implements GenLitePlugin {
     disableDragOnShift: boolean = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
-        this.disableDragOnShift = window.genlite.settings.add(
+        document.genlite.registerPlugin(this);
+        this.disableDragOnShift = document.genlite.settings.add(
             "Inventory.ShiftDisableDrag",
             true,
             "Disable Dragging w/ Shift",

--- a/src/plugins/genlite-item-highlight.plugin.ts
+++ b/src/plugins/genlite-item-highlight.plugin.ts
@@ -72,13 +72,13 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
     hideLables: boolean = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
         this.originalItemStackIntersects = document.game.ItemStack.intersects;
 
         this.loadItemList();
         this.createDiv();
 
-        this.isPluginEnabled = window.genlite.settings.add(
+        this.isPluginEnabled = document.genlite.settings.add(
             "ItemHighlight.Enable",
             true,
             "Highlight Items",
@@ -88,7 +88,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
             undefined,
             undefined
         );
-        this.hideLables = window.genlite.settings.add(
+        this.hideLables = document.genlite.settings.add(
             "HideItemLabels.Enable",
             false,
             "Hide Item Labels",
@@ -100,7 +100,7 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
             "ItemHighlight.Enable"
         );
 
-        let storedPriorityColor = window.genlite.settings.add("ItemHighlight.PriorityColor", "#ffa500", "Priority Item Color", "color", this.handleColorChange, this, undefined, undefined, "ItemHighlight.Enable");
+        let storedPriorityColor = document.genlite.settings.add("ItemHighlight.PriorityColor", "#ffa500", "Priority Item Color", "color", this.handleColorChange, this, undefined, undefined, "ItemHighlight.Enable");
 
         let sheet = document.styleSheets[0];
         this.styleRuleIndex = sheet.insertRule(`.genlite-priority-item { color: ${storedPriorityColor}; }`, sheet.cssRules.length);
@@ -182,8 +182,8 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
         //     itemName= `${itemName}(${item.definition.quantity})`;
         // }
         div.innerHTML = `<span style="display: inline-block;">${itemName}</span>
-                             <div class="genlite-item-setting" style="display: ${this.isAltDown ? "inline-block" : "none"}; pointer-events: auto;" onclick="window.${GenLiteItemHighlightPlugin.pluginName}.hideItem('${itemId}');void(0);"> &#8863;</div>
-                             <div class="genlite-item-setting" style="display: ${this.isAltDown ? "inline-block" : "none"}; pointer-events: auto;" onclick="window.${GenLiteItemHighlightPlugin.pluginName}.importantItem('${itemId}');void(0);"> &#8862;</div>`;
+                             <div class="genlite-item-setting" style="display: ${this.isAltDown ? "inline-block" : "none"}; pointer-events: auto;" onclick="document.${GenLiteItemHighlightPlugin.pluginName}.hideItem('${itemId}');void(0);"> &#8863;</div>
+                             <div class="genlite-item-setting" style="display: ${this.isAltDown ? "inline-block" : "none"}; pointer-events: auto;" onclick="document.${GenLiteItemHighlightPlugin.pluginName}.importantItem('${itemId}');void(0);"> &#8862;</div>`;
         div.style.transform = 'translateX(-50%)';
         div.style.pointerEvents = "none";
         div.style.fontFamily = 'acme, times new roman, Times, serif'; // Set Font
@@ -355,13 +355,13 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
         all_items.sort((a, b) => b.item.value - a.item.value);
 
         let show_examine_options = true;
-        if (all_items.length > window.game.ITEM_RIGHTCLICK_LIMIT / 2) show_examine_options = false;
+        if (all_items.length > document.game.ITEM_RIGHTCLICK_LIMIT / 2) show_examine_options = false;
 
         let options = 0;
         for (let entry of all_items) {
             let itemId = entry.id;
             let item = entry.item;
-            if (options > window.game.ITEM_RIGHTCLICK_LIMIT) break;
+            if (options > document.game.ITEM_RIGHTCLICK_LIMIT) break;
             options++;
             if (show_examine_options) {
                 list.push({
@@ -377,12 +377,12 @@ export class GenLiteItemHighlightPlugin implements GenLitePlugin {
             list.push({
                 color: 'red',
                 distance: i.distance,
-                priority: 1 + window[GenLiteItemHighlightPlugin.pluginName].getItemData(itemId) * 50,
+                priority: 1 + document[GenLiteItemHighlightPlugin.pluginName].getItemData(itemId) * 50,
                 object: item,
                 text: all_keys.length > 1 ? 'Take one' : 'Take',
                 action: () => {
                     let take_id = all_keys[Math.floor(Math.random() * all_keys.length)];
-                    window.game.NETWORK.action('take', {
+                    document.game.NETWORK.action('take', {
                         item: take_id
                     })
                 }

--- a/src/plugins/genlite-item-tooltips.plugin.ts
+++ b/src/plugins/genlite-item-tooltips.plugin.ts
@@ -29,11 +29,11 @@ export class GenLiteItemTooltips implements GenLitePlugin {
     isValueEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
-        this.isPluginEnabled = window.genlite.settings.add("ItemToolTips.Enable", true, "Tooltips", "checkbox", this.handlePluginEnableDisable, this);
-        this.isFoodEnabled = window.genlite.settings.add("FoodToolTips.Enable", true, "Food Tooltips", "checkbox", this.handleFoodEnableDisable, this, undefined, undefined, "ItemToolTips.Enable");
-        this.isValueEnabled = window.genlite.settings.add("ValueToolTips.Enable", true, "Value Tooltips", "checkbox", this.handleValueEnableDisable, this, undefined, undefined, "ItemToolTips.Enable");
+        this.isPluginEnabled = document.genlite.settings.add("ItemToolTips.Enable", true, "Tooltips", "checkbox", this.handlePluginEnableDisable, this);
+        this.isFoodEnabled = document.genlite.settings.add("FoodToolTips.Enable", true, "Food Tooltips", "checkbox", this.handleFoodEnableDisable, this, undefined, undefined, "ItemToolTips.Enable");
+        this.isValueEnabled = document.genlite.settings.add("ValueToolTips.Enable", true, "Value Tooltips", "checkbox", this.handleValueEnableDisable, this, undefined, undefined, "ItemToolTips.Enable");
 
 
     }

--- a/src/plugins/genlite-locations.plugin.ts
+++ b/src/plugins/genlite-locations.plugin.ts
@@ -144,17 +144,17 @@ export class GenLiteLocationsPlugin implements GenLitePlugin {
         document.body.appendChild(this.mapIframe)
     }
     async init() {
-        window.genlite.registerPlugin(this)
+        document.genlite.registerPlugin(this)
 
 
 
-        this.locationLabels = window.genlite.settings.add("LocationLabels.Enable", true, "Location Labels", "checkbox", this.handleLocationLabelsEnableDisable, this)
-        this.showCoordinates = window.genlite.settings.add("Coordinates.Enable", true, "Coordinates", "checkbox", this.handleShowCoordinatesDisable, this, undefined, undefined, "LocationLabels.Enable")
-        this.compassMap = window.genlite.settings.add("CompassMap.Enable", true, "Compass Map", "checkbox", this.handleCompassMapEnableDisable, this)
+        this.locationLabels = document.genlite.settings.add("LocationLabels.Enable", true, "Location Labels", "checkbox", this.handleLocationLabelsEnableDisable, this)
+        this.showCoordinates = document.genlite.settings.add("Coordinates.Enable", true, "Coordinates", "checkbox", this.handleShowCoordinatesDisable, this, undefined, undefined, "LocationLabels.Enable")
+        this.compassMap = document.genlite.settings.add("CompassMap.Enable", true, "Compass Map", "checkbox", this.handleCompassMapEnableDisable, this)
 
         //Decide how to handle initial setting grab as right now only returns true/false
         this.translucentScale = 0.5
-        window.genlite.settings.add("CompassMapTranslucentScale", true, "Compass Map Translucent Scale", "range", this.handleCompassMapTranslucentSlider, this, undefined,
+        document.genlite.settings.add("CompassMapTranslucentScale", true, "Compass Map Translucent Scale", "range", this.handleCompassMapTranslucentSlider, this, undefined,
             [['min', '0.01'], ['max', '1'], ['step', '0.01'], ['value', '0.5'], ['class', 'gen-slider']], "CompassMap.Enable");
 
         this.addStylesheet()

--- a/src/plugins/genlite-menu-scaler.plugin.ts
+++ b/src/plugins/genlite-menu-scaler.plugin.ts
@@ -21,10 +21,10 @@ export class GenLiteMenuScaler implements GenLitePlugin {
     isPluginEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
         this.scaleList = {};
-        this.isPluginEnabled = window.genlite.settings.add("MenuScaler.Enable", true, "MenuScaler", "checkbox", this.handlePluginEnableDisable, this);
-        this.scaleList.rightClick = window.genlite.settings.add("MenuScalerRightCLick.1", true, "Scale Right Click Menu", "range", this.scaleRightClick, this, undefined,
+        this.isPluginEnabled = document.genlite.settings.add("MenuScaler.Enable", true, "MenuScaler", "checkbox", this.handlePluginEnableDisable, this);
+        this.scaleList.rightClick = document.genlite.settings.add("MenuScalerRightCLick.1", true, "Scale Right Click Menu", "range", this.scaleRightClick, this, undefined,
             [['min', '0.1'], ['max', '4'], ['step', '0.1'], ['value', '1']], "MenuScaler.Enable");
     }
 

--- a/src/plugins/genlite-menuswapper.plugin.ts
+++ b/src/plugins/genlite-menuswapper.plugin.ts
@@ -25,11 +25,11 @@ export class GenLiteMenuSwapperPlugin implements GenLitePlugin {
 
     intersect_vector = new document.game.THREE.Vector3();
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
-        this.useOneClickBank = window.genlite.settings.add("NPCMenuSwapper.LeftClickBank", true, "Left Click Bank", "checkbox", this.handleLeftClickBankToggle, this);
-        this.useOneClickTrade = window.genlite.settings.add("NPCMenuSwapper.LeftClickTrade", true, "Left Click Trade", "checkbox", this.handleLeftClickTradeToggle, this);
-        this.hideStairs = window.genlite.settings.add("NPCMenuSwapper.hideStairs", false, "Hide Stairs", "checkbox", this.handleHideStairsToggle, this);
+        this.useOneClickBank = document.genlite.settings.add("NPCMenuSwapper.LeftClickBank", true, "Left Click Bank", "checkbox", this.handleLeftClickBankToggle, this);
+        this.useOneClickTrade = document.genlite.settings.add("NPCMenuSwapper.LeftClickTrade", true, "Left Click Trade", "checkbox", this.handleLeftClickTradeToggle, this);
+        this.hideStairs = document.genlite.settings.add("NPCMenuSwapper.hideStairs", false, "Hide Stairs", "checkbox", this.handleHideStairsToggle, this);
 
         this.originalSceneIntersects = OptimizedScene.prototype.intersects;
         this.originalNPCIntersects = NPC.prototype.intersects;
@@ -102,7 +102,7 @@ export class GenLiteMenuSwapperPlugin implements GenLitePlugin {
             list.push({
                 color: 'red',
                 distance: i.distance,
-                priority: window[GenLiteMenuSwapperPlugin.pluginName].useOneClickTrade ? 15 : 1,
+                priority: document[GenLiteMenuSwapperPlugin.pluginName].useOneClickTrade ? 15 : 1,
                 object: this,
                 text: "Trade with",
                 action: () => self.trade()
@@ -111,7 +111,7 @@ export class GenLiteMenuSwapperPlugin implements GenLitePlugin {
             list.push({
                 color: 'red',
                 distance: i.distance,
-                priority: window[GenLiteMenuSwapperPlugin.pluginName].useOneClickBank ? 15 : 1,
+                priority: document[GenLiteMenuSwapperPlugin.pluginName].useOneClickBank ? 15 : 1,
                 object: this,
                 text: "Bank with",
                 action: () => self.bank()
@@ -129,7 +129,7 @@ export class GenLiteMenuSwapperPlugin implements GenLitePlugin {
 
             let oi;
             if (o.bounding_box) {
-                let point = ray.ray.intersectBox(o.bounding_box, window[GenLiteMenuSwapperPlugin.pluginName].intersect_vector);
+                let point = ray.ray.intersectBox(o.bounding_box, document[GenLiteMenuSwapperPlugin.pluginName].intersect_vector);
                 oi = point ? [point] : [];
             } else {
                 oi = ray.intersectObject(o.mesh, true);
@@ -139,7 +139,7 @@ export class GenLiteMenuSwapperPlugin implements GenLitePlugin {
                 let actions = thing.actions();
                 for (let i in actions) {
                     /* if stairs or ladder depo if setting checked */
-                    if (window[GenLiteMenuSwapperPlugin.pluginName].hideStairs && !KEYBOARD['16']) { //its conveint genfanad keeps track of all keyboard keys
+                    if (document[GenLiteMenuSwapperPlugin.pluginName].hideStairs && !KEYBOARD['16']) { //its conveint genfanad keeps track of all keyboard keys
                         switch (actions[i].text) {
                             case "Climb up":
                             case "Climb down":

--- a/src/plugins/genlite-music.plugin.ts
+++ b/src/plugins/genlite-music.plugin.ts
@@ -41,10 +41,10 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
     currentTrack = "";
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
         this.originalSetTrack = document.game.MUSIC_PLAYER.setNextTrack;
 
-        this.isPluginEnabled = window.genlite.settings.add(
+        this.isPluginEnabled = document.genlite.settings.add(
             "MusicPlugin.Enable",
             false,
             "Music Selection",
@@ -108,7 +108,7 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
             this.selectionOptions[track] = b;
         }
 
-        window.genlite.commands.register(
+        document.genlite.commands.register(
             "music",
             this.handleCommand.bind(this),
             this.helpCommand.bind(this)
@@ -229,20 +229,20 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
 
         switch (subcommand) {
             case "list":
-                window.genlite.commands.print("List available tracks.");
+                document.genlite.commands.print("List available tracks.");
                 break;
             case "play":
-                window.genlite.commands.print("Play a track; e.g. '//music play Genfanad Theme'");
+                document.genlite.commands.print("Play a track; e.g. '//music play Genfanad Theme'");
                 break;
             case "shuffle":
-                window.genlite.commands.print("Enable or disable shuffle; e.g. '//music shuffle off'");
+                document.genlite.commands.print("Enable or disable shuffle; e.g. '//music shuffle off'");
                 break;
             case "default":
-                window.genlite.commands.print("Restore to default Genfanad music");
+                document.genlite.commands.print("Restore to default Genfanad music");
                 break;
             default:
-                window.genlite.commands.print("Controls music player.");
-                window.genlite.commands.print("subcommands: list, play, shuffle, default");
+                document.genlite.commands.print("Controls music player.");
+                document.genlite.commands.print("subcommands: list, play, shuffle, default");
                 break;
         }
     }
@@ -261,7 +261,7 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
                 for (const track in this.selectionOptions) {
                     names.push(this.selectionOptions[track].innerText);
                 }
-                window.genlite.commands.print(names.join(", "));
+                document.genlite.commands.print(names.join(", "));
                 break;
             case "play":
                 let song = arg;
@@ -270,7 +270,7 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
                     if (this.selectionOptions[song]) {
                         this.setManual();
                         this.setNextTrack(song);
-                        window.genlite.commands.print("playing: " + song);
+                        document.genlite.commands.print("playing: " + song);
                         return;
                     }
 
@@ -286,16 +286,16 @@ export class GenLiteMusicPlugin implements GenLitePlugin {
                     }
 
                     if (matches.length == 0) {
-                        window.genlite.commands.print("no such song");
+                        document.genlite.commands.print("no such song");
                     } else if (matches.length == 1) {
                         this.setManual();
                         this.setNextTrack(tracks[0]);
-                        window.genlite.commands.print("playing: " + matches[0]);
+                        document.genlite.commands.print("playing: " + matches[0]);
                     } else {
-                        window.genlite.commands.print("be more specific: " + matches.join(", "));
+                        document.genlite.commands.print("be more specific: " + matches.join(", "));
                     }
                 } else {
-                    window.genlite.commands.print("specify a track to play");
+                    document.genlite.commands.print("specify a track to play");
                     this.helpCommand("play");
                 }
                 break;

--- a/src/plugins/genlite-npc-highlight.plugin.ts
+++ b/src/plugins/genlite-npc-highlight.plugin.ts
@@ -37,7 +37,7 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
 
     packList;
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
         this.npc_highlight_div = document.createElement('div');
         this.npc_highlight_div.className = 'npc-indicators-list';
@@ -53,13 +53,13 @@ export class GenLiteNPCHighlightPlugin implements GenLitePlugin {
         window.addEventListener('keyup', this.keyUpHandler.bind(this));
         window.addEventListener("blur", this.blurHandler.bind(this))
 
-        this.isPluginEnabled = window.genlite.settings.add("NpcHighlight.Enable", true, "Highlight NPCs", "checkbox", this.handlePluginEnableDisable, this);
-        this.hideInvert = window.genlite.settings.add("NpcHideInvert.Enable", true, "Invert NPC Hiding", "checkbox", this.handleHideInvertEnableDisable, this, undefined, undefined, "NpcHighlight.Enable");
+        this.isPluginEnabled = document.genlite.settings.add("NpcHighlight.Enable", true, "Highlight NPCs", "checkbox", this.handlePluginEnableDisable, this);
+        this.hideInvert = document.genlite.settings.add("NpcHideInvert.Enable", true, "Invert NPC Hiding", "checkbox", this.handleHideInvertEnableDisable, this, undefined, undefined, "NpcHighlight.Enable");
 
     }
 
     async postInit() {
-        this.packList = window.GenLiteWikiDataCollectionPlugin.packList;
+        this.packList = document['GenLiteWikiDataCollectionPlugin'].packList;
     }
 
     handlePluginEnableDisable(state: boolean) {

--- a/src/plugins/genlite-playertools.plugin.ts
+++ b/src/plugins/genlite-playertools.plugin.ts
@@ -27,7 +27,7 @@ export class GenLitePlayerToolsPlugin implements GenLitePlugin {
 
     // Plugin Hooks
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
         // Create and Append the Player Tag Container to the Body
         this.PlayerTagContainer = document.createElement('div');
@@ -35,7 +35,7 @@ export class GenLitePlayerToolsPlugin implements GenLitePlugin {
         document.body.appendChild(this.PlayerTagContainer);
 
         // Add Settings to the Settings Menu
-        this.isEnabled = window.genlite.settings.add(
+        this.isEnabled = document.genlite.settings.add(
             "PlayerHighlights.Enabled",
             true,
             "Enable Player Highlights",
@@ -43,7 +43,7 @@ export class GenLitePlayerToolsPlugin implements GenLitePlugin {
             this.handleHighlightSettingChange,
             this);
 
-        window.genlite.settings.add(
+        document.genlite.settings.add(
             "PlayerTools.HidePlayer",
             false,
             "Hide My Character",

--- a/src/plugins/genlite-recipe-recorder.plugin.ts
+++ b/src/plugins/genlite-recipe-recorder.plugin.ts
@@ -33,7 +33,7 @@ export class GenLiteRecipeRecorderPlugin implements GenLitePlugin {
     isPluginEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
         let dropTableString = localStorage.getItem("GenliteRecipeRecorder")
         if (dropTableString == null) {
             this.recipeResults = {};
@@ -43,7 +43,7 @@ export class GenLiteRecipeRecorderPlugin implements GenLitePlugin {
             this.recipeResults = saved.recipe ? saved.recipe : {};
             this.gatherResults = saved.gathering ? saved.gathering : {};
         }
-        this.isPluginEnabled = window.genlite.settings.add("RecipeRecorder.Enable", true, "Record Recipes", "checkbox", this.handlePluginEnableDisable, this);
+        this.isPluginEnabled = document.genlite.settings.add("RecipeRecorder.Enable", true, "Record Recipes", "checkbox", this.handlePluginEnableDisable, this);
     }
 
     handlePluginEnableDisable(state: boolean) {

--- a/src/plugins/genlite-sound-notification.plugin.ts
+++ b/src/plugins/genlite-sound-notification.plugin.ts
@@ -32,22 +32,22 @@ export class GenLiteSoundNotification implements GenLitePlugin {
 
 
     async init() {
-        window.genlite.registerPlugin(this);
-        this.doHealthCheck = window.genlite.settings.add("LowHealth.Enable", false, "Low Health Sound", "checkbox", this.handleDoHealthCheck, this);
+        document.genlite.registerPlugin(this);
+        this.doHealthCheck = document.genlite.settings.add("LowHealth.Enable", false, "Low Health Sound", "checkbox", this.handleDoHealthCheck, this);
         //this is a stupid ass thing but *shrug*
-        this.healthThreshold = window.genlite.settings.add("LowHealth.0", 0, "Low Health Threshold: <div style=\"display: contents;\" id=\"GenLiteHealthThresholdOutput\"></div>", "range", this.setHealthThreshold, this, undefined,
+        this.healthThreshold = document.genlite.settings.add("LowHealth.0", 0, "Low Health Threshold: <div style=\"display: contents;\" id=\"GenLiteHealthThresholdOutput\"></div>", "range", this.setHealthThreshold, this, undefined,
             [['min', '1'], ['max', '100'], ['step', '1'], ['value', '0']], "LowHealth.Enable");
         document.getElementById("GenLiteHealthThresholdOutput").innerText = ` ${this.healthThreshold}%`
 
-        this.doInvCheck = window.genlite.settings.add("InvCheck.Enable", false, "Inventory Space Sound", "checkbox", this.handleInvCheckEnableDisable, this);
+        this.doInvCheck = document.genlite.settings.add("InvCheck.Enable", false, "Inventory Space Sound", "checkbox", this.handleInvCheckEnableDisable, this);
         //this is a stupid ass thing but *shrug*
-        this.invThreshold = window.genlite.settings.add("InvThreshold.0", 0, "Inventory Threshold: <div style=\"display: contents;\" id=\"GenLiteInvThresholdOutput\"></div>", "range", this.setInvThreshold, this, undefined,
+        this.invThreshold = document.genlite.settings.add("InvThreshold.0", 0, "Inventory Threshold: <div style=\"display: contents;\" id=\"GenLiteInvThresholdOutput\"></div>", "range", this.setInvThreshold, this, undefined,
             [['min', '1'], ['max', '30'], ['step', '1'], ['value', '0']], "InvCheck.Enable");
         document.getElementById("GenLiteInvThresholdOutput").innerText = ` ${this.invThreshold}`
 
 
-        this.overrideIGNVolume = window.genlite.settings.add("overrideIGNVolume.Enable", false, "Override Game Volume", "checkbox", this.handelOverrideVolumeEnableDisable, this);
-        this.overrideVolume = window.genlite.settings.add("overrideVolume.0", 0, "Override Game Volume: <div style=\"display: contents;\" id=\"GenLiteOverrideVolumeOutput\"></div>", "range", this.setOverrideVolume, this, undefined,
+        this.overrideIGNVolume = document.genlite.settings.add("overrideIGNVolume.Enable", false, "Override Game Volume", "checkbox", this.handelOverrideVolumeEnableDisable, this);
+        this.overrideVolume = document.genlite.settings.add("overrideVolume.0", 0, "Override Game Volume: <div style=\"display: contents;\" id=\"GenLiteOverrideVolumeOutput\"></div>", "range", this.setOverrideVolume, this, undefined,
             [['min', '1'], ['max', '100'], ['step', '1'], ['value', '0']], "overrideIGNVolume.Enable");
         document.getElementById("GenLiteOverrideVolumeOutput").innerText = ` ${this.overrideVolume}%`;
 

--- a/src/plugins/genlite-version.plugin.ts
+++ b/src/plugins/genlite-version.plugin.ts
@@ -28,7 +28,7 @@ export class GenLiteVersionPlugin implements GenLitePlugin {
 
     // Plugin Hooks
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
         // Create and Append the Version Container to the Body
         this.versionContainer = document.createElement('p');

--- a/src/plugins/genlite-wiki-data-collection.plugin.ts
+++ b/src/plugins/genlite-wiki-data-collection.plugin.ts
@@ -32,9 +32,9 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
     sendInterval: NodeJS.Timer = null;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
 
-        this.isRemoteEnabled = window.genlite.settings.add(
+        this.isRemoteEnabled = document.genlite.settings.add(
             "WikiDataColl.Enable",
             false,
             "Wiki Data collection(REMOTE SERVER)",
@@ -100,7 +100,7 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
         if (this.previously_seen[mobKey].Monster_HP == 0) { // if we havent seen the monster or if we dont know its health
             this.previously_seen[mobKey].Monster_HP = update.maxhp;
             if (this.isRemoteEnabled && this.previously_seen[mobKey].numSeen >= 100)
-                window.genlite.sendDataToServer("monsterdata", this.previously_seen[mobKey]);
+                document.genlite.sendDataToServer("monsterdata", this.previously_seen[mobKey]);
         }
     }
 
@@ -170,7 +170,7 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
         this.previously_seen[mobKey].Base_Xp = baseXp;
         this.previously_seen[mobKey].Level_Diff_Bit = 0;
         if (this.isRemoteEnabled && this.previously_seen[mobKey].numSeen >= 100)
-            window.genlite.sendDataToServer("monsterdata", this.previously_seen[mobKey]);
+            document.genlite.sendDataToServer("monsterdata", this.previously_seen[mobKey]);
     }
 
     scanNpcs() {
@@ -252,6 +252,6 @@ export class GenLiteWikiDataCollectionPlugin implements GenLitePlugin {
         if (callback_this.toSend.length <= 0)
             return;
         let monsterdata = callback_this.toSend.pop();
-        window.genlite.sendDataToServer("monsterdata", monsterdata);
+        document.genlite.sendDataToServer("monsterdata", monsterdata);
     }
 }

--- a/src/plugins/genlite-xp-calculator.plugin.ts
+++ b/src/plugins/genlite-xp-calculator.plugin.ts
@@ -57,9 +57,9 @@ export class GenLiteXpCalculator implements GenLitePlugin {
     isPluginEnabled: boolean = false;
 
     async init() {
-        window.genlite.registerPlugin(this);
+        document.genlite.registerPlugin(this);
         this.resetCalculatorAll();
-        this.isPluginEnabled = window.genlite.settings.add("XPCalculator.Enable", true, "XP Calculator", "checkbox", this.handlePluginEnableDisable, this);
+        this.isPluginEnabled = document.genlite.settings.add("XPCalculator.Enable", true, "XP Calculator", "checkbox", this.handlePluginEnableDisable, this);
     }
 
     handlePluginEnableDisable(state: boolean) {


### PR DESCRIPTION
This setting is required in order for GenLite to load early enough and intercept client.js loading.

bug fixes:
1. GenLite was double-initializing plugins. We can revert the change when changed to init on page load again instead of on login.
2. Our window object at init was different than at runtime (maybe because of change to instant/document-start). Moved all of our globals to document instead.