### PR TITLE
fix font loading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,10 @@ Press Cancel to Load, Press Okay to Stop.`;
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
 let scriptText = GM_getResourceText('clientjs');
+scriptText = scriptText.replace(
+    /import.meta.url/g,
+    '("https://play.genfanad.com/play/js/client.js")'
+);
 scriptText = scriptText.substring(0, scriptText.length - 5)
     + "; document.client = {};"
     + "document.client.get = function(a) {"


### PR DESCRIPTION
Since we remove the original script src, import.meta.url resolves to the wrong url. This causes the acme font to break.

The string replace might be slow, a better fix might be to overwrite import.meta.url somehow, or fetch the font on our own. But for now, this works.