### PR TITLE
Dev/health regeneration plugin 1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,13 +39,19 @@ import { GenLiteSoundNotification } from "./plugins/genlite-sound-notification.p
 import { GenLiteGeneralChatCommands } from "./plugins/genlite-generalchatcommand.plugin";
 import { GenLitePlayerToolsPlugin } from "./plugins/genlite-playertools.plugin";
 import { GenLiteHighscores } from "./plugins/genlite-highscores.plugin";
+import { GenLiteHealthRegenerationPlugin } from './plugins/genlite-health-regeneration.plugin';
 
 declare const GM_getResourceText: (s: string) => string;
+
+// TODO: use globals.ts?
 declare global {
     interface Document {
         game: any;
         client: any;
-        genlite: any;
+        genlite: {
+          [key: string]: any,
+          settings: GenLiteSettingsPlugin,
+        };
         initGenLite: () => void;
     }
 }
@@ -202,6 +208,7 @@ let isInitialized = false;
         await genlite.pluginLoader.addPlugin(GenLiteGeneralChatCommands);
         await genlite.pluginLoader.addPlugin(GenLitePlayerToolsPlugin);
         await genlite.pluginLoader.addPlugin(GenLiteHighscores);
+        await genlite.pluginLoader.addPlugin(GenLiteHealthRegenerationPlugin);
 
         /** post init things */
         await document['GenLiteSettingsPlugin'].postInit();

--- a/src/plugins/genlite-health-regeneration.plugin.ts
+++ b/src/plugins/genlite-health-regeneration.plugin.ts
@@ -1,0 +1,45 @@
+import { GenLitePlugin } from '../core/interfaces/plugin.interface';
+
+export class GenLiteHealthRegenerationPlugin implements GenLitePlugin {
+    static pluginName = 'GenLiteHealthRegenerationPlugin';
+
+    healthRegenerationInterval;
+
+    // TODO: Host as @resource?
+    healthRegenAudio = new Audio('https://furious.no/downloads/genfanad/ping.wav');
+    healthBarText: HTMLElement = this.getHealthBarText();
+    oldHealth = -Infinity;
+
+    static healthRegenerationIntervalMilliseconds = 100;
+
+    async init() {
+        this.start();
+    }
+
+    public stop() {
+      clearInterval(this.healthRegenerationInterval);
+    }
+
+    public start() {
+        this.healthRegenerationInterval = setInterval(() => {
+            if (!this.healthBarText) {
+              this.healthBarText = this.getHealthBarText();
+            }
+
+            const health = Number(this.healthBarText.innerText);
+
+            const diff = Math.floor(health - this.oldHealth);
+
+            if (diff === 1) {
+              this.healthRegenAudio.play();
+            }
+
+            this.oldHealth = health;
+
+        }, GenLiteHealthRegenerationPlugin.healthRegenerationIntervalMilliseconds);
+    }
+
+    getHealthBarText(): HTMLElement {
+      return document.querySelector('#new_ux-hp__numbers__wrapper #new_ux-hp__number--actual') as HTMLElement;
+    }
+}

--- a/src/plugins/genlite-health-regeneration.plugin.ts
+++ b/src/plugins/genlite-health-regeneration.plugin.ts
@@ -9,11 +9,31 @@ export class GenLiteHealthRegenerationPlugin implements GenLitePlugin {
     healthRegenAudio = new Audio('https://furious.no/downloads/genfanad/ping.wav');
     healthBarText: HTMLElement = this.getHealthBarText();
     oldHealth = -Infinity;
+    isPluginEnabled: boolean = false;
 
     static healthRegenerationIntervalMilliseconds = 100;
 
     async init() {
-        this.start();
+        this.isPluginEnabled = document.genlite.settings.add(
+          "HealthRegenerationAudioNotify.Enable",
+          false,
+          "Health Regeneration Audio Notification",
+          "checkbox",
+          this.handlePluginToggled,
+          this
+        );
+
+        this.handlePluginToggled(this.isPluginEnabled);
+    }
+
+    handlePluginToggled(state: boolean) {
+        this.isPluginEnabled = state;
+
+        if (state) {
+          this.start();
+        } else {
+          this.stop();
+        }
     }
 
     public stop() {


### PR DESCRIPTION
Checks health bar of the player in the top left corner for a +1 increment at an interval of 100ms

Plugin should be off by default (if I did the whole settings thing correctly)

Added settings as a global entry on Document interface so that the settings.add() function shows parameters automatically for some editors like WebStorm

